### PR TITLE
libtego_ui, libtego: reimplemented global unread counter for macOS dock icon

### DIFF
--- a/src/libtego/source/core/ContactsManager.cpp
+++ b/src/libtego/source/core/ContactsManager.cpp
@@ -176,12 +176,6 @@ void ContactsManager::onUnreadCountChanged()
     ContactUser *user = model->contact();
 
     emit unreadCountChanged(user, model->unreadCount());
-
-// TODO: move this out of libtego
-#ifdef Q_OS_MAC
-    int unread = globalUnreadCount();
-    QtMac::setBadgeLabelText(unread == 0 ? QString() : QString::number(unread));
-#endif
 }
 
 int ContactsManager::globalUnreadCount() const

--- a/src/libtego/source/precomp.h
+++ b/src/libtego/source/precomp.h
@@ -116,9 +116,6 @@ extern "C" {
 #include <QtGlobal>
 #include <QTime>
 #include <QTimer>
-#ifdef Q_OS_MAC
-#   include <QtMac>
-#endif // Q_OS_MAC
 #include <QtQml>
 #include <QUrl>
 #include <QVariant>

--- a/src/libtego_ui/precomp.hpp
+++ b/src/libtego_ui/precomp.hpp
@@ -25,6 +25,9 @@
 #include <QRegularExpressionValidator>
 #include <QScreen>
 #include <QtQml>
+#ifdef Q_OS_MAC
+#   include <QtMac>
+#endif // Q_OS_MAC
 
 // tego
 #include <tego/tego.hpp>

--- a/src/libtego_ui/shims/ConversationModel.h
+++ b/src/libtego_ui/shims/ConversationModel.h
@@ -48,8 +48,10 @@ namespace shims
 
     signals:
         void contactChanged();
-        void unreadCountChanged();
+        void unreadCountChanged(int prevCount, int currentCount);
     private:
+        void setUnreadCount(int count);
+
         shims::ContactUser* contactUser = nullptr;
 
         struct MessageData


### PR DESCRIPTION
We have a fair bit of now uncalled UI code in libtego, and setting the macOS dock icon logic is part of it. This patch moves the global unread count logic into the unreadCountChanged signal in shims/ConversationModel.cpp. 