### PR TITLE
issue_27: fixed app icon display on Linux

### DIFF
--- a/src/tego_ui/icons/icons.qrc
+++ b/src/tego_ui/icons/icons.qrc
@@ -1,6 +1,6 @@
 <RCC>
     <qresource prefix="/icons">
-        <file>ricochet_refresh.svg</file>
+        <file>ricochet_refresh.png</file>
         <file>ricochet_icons.ttf</file>
     </qresource>
 </RCC>

--- a/src/tego_ui/main.cpp
+++ b/src/tego_ui/main.cpp
@@ -85,7 +85,7 @@ int main(int argc, char *argv[]) try
     a.setOrganizationName(QStringLiteral("Ricochet"));
 
 #if !defined(Q_OS_WIN) && !defined(Q_OS_MAC)
-    a.setWindowIcon(QIcon(QStringLiteral(":/icons/ricochet_refresh.svg")));
+    a.setWindowIcon(QIcon(QStringLiteral(":/icons/ricochet_refresh.png")));
 #endif
 
     QScopedPointer<SettingsFile> settings(new SettingsFile);


### PR DESCRIPTION
- svg app icons require a plugin to display on Linux
- switched over to using our png icon
- no real change to presentation, as our svg icon is just an embedded png