### PR TITLE
issue_28: fixed crash on launch bug on 64-bit Windows

### DIFF
--- a/src/libtego/source/context.cpp
+++ b/src/libtego/source/context.cpp
@@ -716,7 +716,13 @@ extern "C"
         return tego::translateExceptions([=]() -> size_t
         {
             TEGO_THROW_IF_NULL(context);
-            TEGO_THROW_IF_FALSE(out_logBuffer);
+            TEGO_THROW_IF_NULL(out_logBuffer);
+
+            // nothing to do if no space to write
+            if (logBufferSize == 0)
+            {
+                return 0;
+            }
 
             // get our tor logs
             const auto& logs = context->get_tor_logs();
@@ -737,6 +743,8 @@ extern "C"
 
             // finally copy at most logBufferSize bytes from logBuffer
             size_t copyCount = std::min(logBufferSize, logBuffer.size());
+            TEGO_THROW_IF_FALSE(copyCount > 0);
+
             std::copy(logBuffer.begin(), logBuffer.begin() + copyCount, out_logBuffer);
             // always write null terminator at the end
             out_logBuffer[copyCount - 1] = 0;

--- a/src/libtego/source/tor_stubs.cpp
+++ b/src/libtego/source/tor_stubs.cpp
@@ -1,3 +1,6 @@
+#include "error.hpp"
+
+#define NOT_USED(...) TEGO_THROW_MSG("{} should never be called", __FUNCTION__)
 
 extern "C"
 {
@@ -51,6 +54,30 @@ extern "C"
     const char* tor_fix_source_file(const char* fname)
     {
 	   return fname;
+    }
+
+    // we only need the following stubs on Windows because link-time optimization is broken
+    // on Windows 64 bit ( https://sourceware.org/bugzilla/show_bug.cgi?id=12762) 
+    void crypto_strongest_rand(uint8_t*, size_t)
+    {
+        NOT_USED();
+    }
+
+    void memwipe(void*, uint8_t, size_t)
+    {
+        NOT_USED();
+    }
+
+    size_t crypto_digest_algorithm_get_length(digest_algorithm_t)
+    {
+        NOT_USED();
+        return {};
+    }
+
+    void* tor_memdup_(const void*, size_t)
+    {
+        NOT_USED();
+        return {};
     }
 #endif
 }

--- a/src/qmake_includes/compiler_flags.pri
+++ b/src/qmake_includes/compiler_flags.pri
@@ -1,11 +1,14 @@
 # get us onto the latest c++
 QMAKE_CXXFLAGS += --std=c++2a
-# enable link time optimization
-QMAKE_CFLAGS += -flto
-QMAKE_CXXFLAGS += -flto
-CONFIG(debug,debug|release) {
-    QMAKE_CFLAGS += -O1
-    QMAKE_CXXFLAGS += -O1
+
+# link time optimization for non-windows targets
+!win32-g++ {
+    QMAKE_CFLAGS += -flto
+    QMAKE_CXXFLAGS += -flto
+    CONFIG(debug,debug|release) {
+        QMAKE_CFLAGS += -O1
+        QMAKE_CXXFLAGS += -O1
+    }
 }
 
 CONFIG(release,debug|release):DEFINES += QT_NO_DEBUG_OUTPUT QT_NO_WARNING_OUTPUT

--- a/src/qmake_includes/linker_flags.pri
+++ b/src/qmake_includes/linker_flags.pri
@@ -2,12 +2,12 @@ win32-g++ {
     QMAKE_LFLAGS += -static
     QMAKE_LFLAGS += -static-libgcc
     QMAKE_LFLAGS += -static-libstdc++
-    # work around issue with link time optimization bug in mingw
-    # https://sourceware.org/bugzilla/show_bug.cgi?id=12762
-    QMAKE_LFLAGS += -Wl,-allow-multiple-definition
 }
 
-CONFIG(debug,debug|release) {
-    QMAKE_LFLAGS += -Wl,-O1
+# link time optimization for non-windows targets
+!win32-g++ {
+    CONFIG(debug,debug|release) {
+        QMAKE_LFLAGS += -Wl,-O1
+    }
+    QMAKE_LFLAGS += -flto
 }
-QMAKE_LFLAGS += -flto


### PR DESCRIPTION
Disables link-time optimization for windows as it is still broken using mingw ( https://sourceware.org/bugzilla/show_bug.cgi?id=12762 ). Patch also fixes a heap corruption now exposed by the program running.

Fixes blueprint-freespeech/ricochet-refresh#28