### PR TITLE
issue_29: fixed bug where sounds were not playing

### DIFF
--- a/src/libtego_ui/libtego_callbacks.cpp
+++ b/src/libtego_ui/libtego_callbacks.cpp
@@ -304,9 +304,11 @@ namespace
                 {
                     case tego_user_status_online:
                         contact->setStatus(shims::ContactUser::Online);
+                        contactsManager->setContactStatus(contact, shims::ContactUser::Online);
                         break;
                     case tego_user_status_offline:
                         contact->setStatus(shims::ContactUser::Offline);
+                        contactsManager->setContactStatus(contact, shims::ContactUser::Offline);
                         break;
                     default:
                         break;

--- a/src/libtego_ui/shims/ConversationModel.cpp
+++ b/src/libtego_ui/shims/ConversationModel.cpp
@@ -111,6 +111,10 @@ namespace shims
         {
             this->unreadCount = count;
             emit unreadCountChanged(oldUnreadCount, unreadCount);
+
+            auto userIdentity = shims::UserIdentity::userIdentity;
+            auto contactsManager = userIdentity->getContacts();
+            contactsManager->setUnreadCount(this->contactUser, count);
         }
     }
 


### PR DESCRIPTION
- audio playback was listening to signals on shims::ContactManager
  but these signals were never being fired
- added appropriate calls to make these signals fire so soundsplay

Fixes blueprint-freespeech/ricochet-refresh#29