### PR TITLE
libtego: fix version handshake message

### DIFF
--- a/src/libtego/source/protocol/Connection.cpp
+++ b/src/libtego/source/protocol/Connection.cpp
@@ -180,7 +180,7 @@ void ConnectionPrivate::setSocket(QTcpSocket *s, Connection::Direction d)
         q->grantAuthentication(Connection::HiddenServiceAuth, serverName);
 
         // Send the introduction version handshake message
-        char intro[] = { 0x49, 0x4D, 0x01, ProtocolVersion, 0 };
+        char intro[] = { 0x49, 0x4D, 0x01, ProtocolVersion };
         if (socket->write(intro, sizeof(intro)) < (int)sizeof(intro)) {
             qDebug() << "Failed writing introduction message to socket";
             q->close();

--- a/src/libtego/source/protocol/Connection_p.h
+++ b/src/libtego/source/protocol/Connection_p.h
@@ -44,7 +44,7 @@ class ConnectionPrivate : public QObject
     Q_DISABLE_COPY(ConnectionPrivate)
 
 public:
-    static const quint8 ProtocolVersion = 3 ;
+    static const quint8 ProtocolVersion = 3;
     static const quint8 ProtocolVersionFailed = 0xff;
     static const int PacketHeaderSize = 4;
     static const int PacketMaxDataSize = UINT16_MAX - PacketHeaderSize;


### PR DESCRIPTION
From doc/protocol.md:

*The client begins the connection by sending the following raw sequence of bytes:*
```
0x49
0x4D
nVersions          // One byte, number of supported protocol versions, must be at least 1
nVersions times:
    version        // One byte, protocol version number
```

#36 can be closed after this