### PR TITLE
Warning fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ ricochet-refresh
 \.vscode/c_cpp_properties\.json
 \.vscode/
 notes/*
+*.log

--- a/src/libtego/include/tego/tego.hpp
+++ b/src/libtego/include/tego/tego.hpp
@@ -62,7 +62,7 @@ TEGO_DEFAULT_DELETE_IMPL(tego_ed25519_private_key)
 TEGO_DEFAULT_DELETE_IMPL(tego_ed25519_public_key)
 TEGO_DEFAULT_DELETE_IMPL(tego_ed25519_signature)
 TEGO_DEFAULT_DELETE_IMPL(tego_v3_onion_service_id)
-TEGO_DEFAULT_DELETE_IMPL(tego_tor_launch_config);
-TEGO_DEFAULT_DELETE_IMPL(tego_tor_daemon_config);
-TEGO_DEFAULT_DELETE_IMPL(tego_user_id);
+TEGO_DEFAULT_DELETE_IMPL(tego_tor_launch_config)
+TEGO_DEFAULT_DELETE_IMPL(tego_tor_daemon_config)
+TEGO_DEFAULT_DELETE_IMPL(tego_user_id)
 

--- a/src/libtego/source/context.cpp
+++ b/src/libtego/source/context.cpp
@@ -692,7 +692,7 @@ extern "C"
                 *out_configured = TEGO_TRUE;
             }
         }, error);
-    };
+    }
 
     size_t tego_context_get_tor_logs_size(
         const tego_context_t* context,

--- a/src/libtego/source/delete.cpp
+++ b/src/libtego/source/delete.cpp
@@ -11,12 +11,12 @@ extern "C"
         delete obj;\
     }
 
-    TEGO_DELETE_IMPL(tego_ed25519_private_key);
-    TEGO_DELETE_IMPL(tego_ed25519_public_key);
-    TEGO_DELETE_IMPL(tego_ed25519_signature);
-    TEGO_DELETE_IMPL(tego_v3_onion_service_id);
-    TEGO_DELETE_IMPL(tego_error);
-    TEGO_DELETE_IMPL(tego_tor_launch_config);
-    TEGO_DELETE_IMPL(tego_tor_daemon_config);
-    TEGO_DELETE_IMPL(tego_user_id);
+    TEGO_DELETE_IMPL(tego_ed25519_private_key)
+    TEGO_DELETE_IMPL(tego_ed25519_public_key)
+    TEGO_DELETE_IMPL(tego_ed25519_signature)
+    TEGO_DELETE_IMPL(tego_v3_onion_service_id)
+    TEGO_DELETE_IMPL(tego_error)
+    TEGO_DELETE_IMPL(tego_tor_launch_config)
+    TEGO_DELETE_IMPL(tego_tor_daemon_config)
+    TEGO_DELETE_IMPL(tego_user_id)
 }

--- a/src/libtego/source/protocol/Connection.cpp
+++ b/src/libtego/source/protocol/Connection.cpp
@@ -180,7 +180,7 @@ void ConnectionPrivate::setSocket(QTcpSocket *s, Connection::Direction d)
         q->grantAuthentication(Connection::HiddenServiceAuth, serverName);
 
         // Send the introduction version handshake message
-        char intro[] = { 0x49, 0x4D, 0x01, ProtocolVersion, 0 };
+        char intro[] = { 0x49, 0x4D, 0x01, ProtocolVersion };
         if (socket->write(intro, sizeof(intro)) < (int)sizeof(intro)) {
             qDebug() << "Failed writing introduction message to socket";
             q->close();

--- a/src/libtego/source/protocol/Connection_p.h
+++ b/src/libtego/source/protocol/Connection_p.h
@@ -44,7 +44,7 @@ class ConnectionPrivate : public QObject
     Q_DISABLE_COPY(ConnectionPrivate)
 
 public:
-    static const quint8 ProtocolVersion = 3 ;
+    static const quint8 ProtocolVersion = 3;
     static const quint8 ProtocolVersionFailed = 0xff;
     static const int PacketHeaderSize = 4;
     static const int PacketMaxDataSize = UINT16_MAX - PacketHeaderSize;

--- a/src/libtego/source/protocol/FileChannel.h
+++ b/src/libtego/source/protocol/FileChannel.h
@@ -42,8 +42,8 @@ namespace Protocol
 
 class FileChannel : public Channel
 {
-    Q_OBJECT;
-    Q_DISABLE_COPY(FileChannel);
+    Q_OBJECT
+    Q_DISABLE_COPY(FileChannel)
 
 public:
     typedef quint32 file_id_t;

--- a/src/libtego/source/signals.cpp
+++ b/src/libtego/source/signals.cpp
@@ -222,18 +222,18 @@ extern "C"
         }, error);\
     }
 
-    TEGO_DEFINE_CALLBACK_SETTER(tor_error_occurred);
-    TEGO_DEFINE_CALLBACK_SETTER(update_tor_daemon_config_succeeded);
-    TEGO_DEFINE_CALLBACK_SETTER(tor_control_status_changed);
-    TEGO_DEFINE_CALLBACK_SETTER(tor_process_status_changed);
-    TEGO_DEFINE_CALLBACK_SETTER(tor_network_status_changed);
-    TEGO_DEFINE_CALLBACK_SETTER(tor_bootstrap_status_changed);
-    TEGO_DEFINE_CALLBACK_SETTER(tor_log_received);
-    TEGO_DEFINE_CALLBACK_SETTER(host_user_state_changed);
-    TEGO_DEFINE_CALLBACK_SETTER(chat_request_received);
-    TEGO_DEFINE_CALLBACK_SETTER(chat_request_response_received);
-    TEGO_DEFINE_CALLBACK_SETTER(message_received);
-    TEGO_DEFINE_CALLBACK_SETTER(message_acknowledged);
-    TEGO_DEFINE_CALLBACK_SETTER(user_status_changed);
-    TEGO_DEFINE_CALLBACK_SETTER(new_identity_created);
+    TEGO_DEFINE_CALLBACK_SETTER(tor_error_occurred)
+    TEGO_DEFINE_CALLBACK_SETTER(update_tor_daemon_config_succeeded)
+    TEGO_DEFINE_CALLBACK_SETTER(tor_control_status_changed)
+    TEGO_DEFINE_CALLBACK_SETTER(tor_process_status_changed)
+    TEGO_DEFINE_CALLBACK_SETTER(tor_network_status_changed)
+    TEGO_DEFINE_CALLBACK_SETTER(tor_bootstrap_status_changed)
+    TEGO_DEFINE_CALLBACK_SETTER(tor_log_received)
+    TEGO_DEFINE_CALLBACK_SETTER(host_user_state_changed)
+    TEGO_DEFINE_CALLBACK_SETTER(chat_request_received)
+    TEGO_DEFINE_CALLBACK_SETTER(chat_request_response_received)
+    TEGO_DEFINE_CALLBACK_SETTER(message_received)
+    TEGO_DEFINE_CALLBACK_SETTER(message_acknowledged)
+    TEGO_DEFINE_CALLBACK_SETTER(user_status_changed)
+    TEGO_DEFINE_CALLBACK_SETTER(new_identity_created)
 }

--- a/src/libtego/source/signals.hpp
+++ b/src/libtego/source/signals.hpp
@@ -78,21 +78,20 @@ namespace tego
                 }\
             }
 
-        TEGO_IMPLEMENT_CALLBACK_FUNCTIONS(tor_error_occurred, tego_tor_error_origin_t, tego_error_t*);
-        TEGO_IMPLEMENT_CALLBACK_FUNCTIONS(update_tor_daemon_config_succeeded, tego_bool_t);
-        TEGO_IMPLEMENT_CALLBACK_FUNCTIONS(tor_control_status_changed, tego_tor_control_status_t);
-        TEGO_IMPLEMENT_CALLBACK_FUNCTIONS(tor_process_status_changed, tego_tor_process_status_t);
-        TEGO_IMPLEMENT_CALLBACK_FUNCTIONS(tor_network_status_changed, tego_tor_network_status_t);
-        TEGO_IMPLEMENT_CALLBACK_FUNCTIONS(tor_bootstrap_status_changed, int32_t, tego_tor_bootstrap_tag_t);
-        TEGO_IMPLEMENT_CALLBACK_FUNCTIONS(tor_log_received, char*, size_t);
-        TEGO_IMPLEMENT_CALLBACK_FUNCTIONS(host_user_state_changed, tego_host_user_state_t);
-        TEGO_IMPLEMENT_CALLBACK_FUNCTIONS(chat_request_received, tego_user_id_t*, char*, size_t);
-        TEGO_IMPLEMENT_CALLBACK_FUNCTIONS(chat_request_response_received, tego_user_id_t*, tego_bool_t);
-        TEGO_IMPLEMENT_CALLBACK_FUNCTIONS(message_received, tego_user_id_t*, tego_time_t, tego_message_id_t,
-            char*, size_t);
-        TEGO_IMPLEMENT_CALLBACK_FUNCTIONS(message_acknowledged, tego_user_id_t*, tego_message_id_t, tego_bool_t);
-        TEGO_IMPLEMENT_CALLBACK_FUNCTIONS(user_status_changed, tego_user_id_t*, tego_user_status_t);
-        TEGO_IMPLEMENT_CALLBACK_FUNCTIONS(new_identity_created, tego_ed25519_private_key_t*);
+        TEGO_IMPLEMENT_CALLBACK_FUNCTIONS(tor_error_occurred, tego_tor_error_origin_t, tego_error_t*)
+        TEGO_IMPLEMENT_CALLBACK_FUNCTIONS(update_tor_daemon_config_succeeded, tego_bool_t)
+        TEGO_IMPLEMENT_CALLBACK_FUNCTIONS(tor_control_status_changed, tego_tor_control_status_t)
+        TEGO_IMPLEMENT_CALLBACK_FUNCTIONS(tor_process_status_changed, tego_tor_process_status_t)
+        TEGO_IMPLEMENT_CALLBACK_FUNCTIONS(tor_network_status_changed, tego_tor_network_status_t)
+        TEGO_IMPLEMENT_CALLBACK_FUNCTIONS(tor_bootstrap_status_changed, int32_t, tego_tor_bootstrap_tag_t)
+        TEGO_IMPLEMENT_CALLBACK_FUNCTIONS(tor_log_received, char*, size_t)
+        TEGO_IMPLEMENT_CALLBACK_FUNCTIONS(host_user_state_changed, tego_host_user_state_t)
+        TEGO_IMPLEMENT_CALLBACK_FUNCTIONS(chat_request_received, tego_user_id_t*, char*, size_t)
+        TEGO_IMPLEMENT_CALLBACK_FUNCTIONS(chat_request_response_received, tego_user_id_t*, tego_bool_t)
+        TEGO_IMPLEMENT_CALLBACK_FUNCTIONS(message_received, tego_user_id_t*, tego_time_t, tego_message_id_t, char*, size_t)
+        TEGO_IMPLEMENT_CALLBACK_FUNCTIONS(message_acknowledged, tego_user_id_t*, tego_message_id_t, tego_bool_t)
+        TEGO_IMPLEMENT_CALLBACK_FUNCTIONS(user_status_changed, tego_user_id_t*, tego_user_status_t)
+        TEGO_IMPLEMENT_CALLBACK_FUNCTIONS(new_identity_created, tego_ed25519_private_key_t*)
 
 
     private:

--- a/src/libtego/source/utils/Useful.h
+++ b/src/libtego/source/utils/Useful.h
@@ -46,6 +46,9 @@
  * Do not confuse bugs with actual error cases; BUG() should never be
  * triggered unless the code or logic is wrong.
  */
+#ifdef BUG
+  #undef BUG
+#endif
 #if !defined(QT_NO_DEBUG) || defined(QT_FORCE_ASSERTS)
 # define BUG() Explode(__FILE__,__LINE__), qWarning() << "BUG:"
 namespace {

--- a/src/libtego_ui/ui/MainWindow.cpp
+++ b/src/libtego_ui/ui/MainWindow.cpp
@@ -71,12 +71,10 @@ public:
     BlockedNetworkAccessManager(QObject *parent)
         : QNetworkAccessManager(parent)
     {
-        /* Either of these is sufficient to cause any network request to fail.
-         * Both of them should be redundant, because createRequest below also
+        /* This will cause any network request to fail.
+         * This should be redundant, because createRequest below also
          * blackholes every request (and crashes for assert builds). */
 
-        /* XXX: setNetworkAccessible is deprecated */
-        setNetworkAccessible(QNetworkAccessManager::NotAccessible);
         setProxy(QNetworkProxy(QNetworkProxy::Socks5Proxy, QLatin1String("0.0.0.0"), 0));
     }
 

--- a/src/libtego_ui/utils/Useful.h
+++ b/src/libtego_ui/utils/Useful.h
@@ -46,6 +46,9 @@
  * Do not confuse bugs with actual error cases; BUG() should never be
  * triggered unless the code or logic is wrong.
  */
+#ifdef BUG
+  #undef BUG
+#endif
 #if !defined(QT_NO_DEBUG) || defined(QT_FORCE_ASSERTS)
 # define BUG() Explode(__FILE__,__LINE__), qWarning() << "BUG:"
 namespace {

--- a/src/qmake_includes/compiler_flags.pri
+++ b/src/qmake_includes/compiler_flags.pri
@@ -1,5 +1,6 @@
 # get us onto the latest c++
-QMAKE_CXXFLAGS += --std=c++2a
+QMAKE_CXXFLAGS += --std=c++2a -Wall -pedantic
+QMAKE_CFLAGS += -Wall -pedantic
 
 # link time optimization for non-windows targets
 !win32-g++ {


### PR DESCRIPTION
Fixes deprecated QT call + most warnings given by -Wpedantic (with the exception of VLAs in `shims::TorControl::setConfiguration`)