### PR TITLE
issue 82: user config now is saved to local app data by default

### DIFF
--- a/src/tego_ui/tego_ui.pro
+++ b/src/tego_ui/tego_ui.pro
@@ -58,59 +58,13 @@ DEFINES += "TEGO_VERSION=$${VERSION}"
     include($${QMAKE_INCLUDES}/hardened.pri)
 }
 
-# Pass DEFINES+=RICOCHET_NO_PORTABLE for a system-wide installation
-contains(DEFINES, RICOCHET_NO_PORTABLE) {
-    unix:!macx {
-        target.path = /usr/bin
-        shortcut.path = /usr/share/applications
-        shortcut.files = ricochet.desktop
-        icon.path = /usr/share/icons/hicolor/48x48/apps/
-        icon.files = icons/ricochet_refresh.png
-        scalable_icon.path = /usr/share/icons/hicolor/scalable/apps/
-        scalable_icon.files = icons/ricochet_refresh.svg
-        INSTALLS += target shortcut icon scalable_icon
-        QMAKE_CLEAN += contrib/usr.bin.ricochet
-        contains(DEFINES, APPARMOR) {
-            apparmor_profile.extra = cp -f $${_PRO_FILE_PWD_}/contrib/usr.bin.ricochet-apparmor $${_PRO_FILE_PWD_}/contrib/usr.bin.ricochet
-            apparmor_profile.files = contrib/usr.bin.ricochet
-            QMAKE_CLEAN += contrib/usr.bin.ricochet
-            !isEmpty(APPARMORDIR) {
-                    apparmor_profile.path = $${APPARMORDIR}/
-            } else {
-                    apparmor_profile.path = /etc/apparmor.d/
-            }
-            INSTALLS += apparmor_profile
-        }
-
-        exists(tor) {
-            message(Adding bundled Tor to installations)
-            bundletor.path = /usr/lib/ricochet/tor/
-            bundletor.files = tor/*
-            INSTALLS += bundletor
-            DEFINES += BUNDLED_TOR_PATH=\\\"/usr/lib/ricochet/tor/\\\"
-        }
-    }
-}
-
 macx {
     CONFIG += bundle force_debug_plist
     QT += macextras
 
     # Qt 5.4 introduces a bug that breaks QMAKE_INFO_PLIST when qmake has a relative path.
     # Work around by copying Info.plist directly.
-    greaterThan(QT_MAJOR_VERSION,5)|greaterThan(QT_MINOR_VERSION,4) {
-        QMAKE_INFO_PLIST = Info.plist
-    } else:equals(QT_MAJOR_VERSION,5):lessThan(QT_MINOR_VERSION,4) {
-        QMAKE_INFO_PLIST = Info.plist
-    } else {
-        CONFIG += no_plist
-        QMAKE_POST_LINK += cp $${_PRO_FILE_PWD_}/Info.plist $${OUT_PWD}/$${TARGET}.app/Contents/;
-    }
-
-    exists(tor) {
-        # Copy the entire tor/ directory, which should contain tor/tor (the binary itself)
-        QMAKE_POST_LINK += cp -R $${_PRO_FILE_PWD_}/tor $${OUT_PWD}/$${TARGET}.app/Contents/MacOS/;
-    }
+    QMAKE_INFO_PLIST = Info.plist
 
     icons.files = icons/ricochet_refresh.icns
     icons.path = Contents/Resources/


### PR DESCRIPTION
- purged RICOCHET_NO_PORTABLE from source
- removed unused RICOCHET_NO_PORTABLE block from tego_ui.pro
- a little bit of pro housekeeping
- application is actually still portable; first argument to command-
  line specifies directory to look for ricochet.json config file