### PR TITLE
issue 84: implement conversation log export

### DIFF
--- a/src/libtego/include/tego/tego.hpp
+++ b/src/libtego/include/tego/tego.hpp
@@ -54,9 +54,11 @@ namespace tego
 
         if (fileHash == nullptr) return {};
 
+        // size of string including null terminator
         const auto hashSize = tego_file_hash_string_size(fileHash, tego::throw_on_error());
 
-        std::string hashString(hashSize, 0);
+        // std::string expects length as arg, not buffer size
+        std::string hashString(hashSize-1, 0);
         tego_file_hash_to_string(fileHash, hashString.data(), hashSize, tego::throw_on_error());
 
         return hashString;

--- a/src/libtego/source/core/ConversationModel.cpp
+++ b/src/libtego/source/core/ConversationModel.cpp
@@ -126,8 +126,8 @@ std::tuple<tego_file_transfer_id_t, std::unique_ptr<tego_file_hash_t>, tego_file
 {
     logger::println("Sending file: {}", file_uri);
 
-    MessageData message(file_uri, QDateTime::currentDateTime(), lastMessageId++, Queued);
-    message.type = ConversationModel::MessageData::Type::File;
+    MessageData message(File, file_uri, QDateTime::currentDateTime(), lastMessageId++, Queued);
+    message.type = ConversationModel::MessageType::File;
 
     std::unique_ptr<tego_file_hash_t> fileHash;
 
@@ -184,8 +184,7 @@ tego_message_id_t ConversationModel::sendMessage(const QString &text)
     if (text.isEmpty())
         return 0;
 
-    MessageData message(text, QDateTime::currentDateTime(), lastMessageId++, Queued);
-    message.type = ConversationModel::MessageData::Type::Message;
+    MessageData message(Message, text, QDateTime::currentDateTime(), lastMessageId++, Queued);
 
     if (m_contact->connection())
     {
@@ -287,14 +286,14 @@ void ConversationModel::sendQueuedMessages()
             bool attempted = false;
             switch (m.type)
             {
-                case ConversationModel::MessageData::Type::Message:
+                case ConversationModel::MessageType::Message:
                     if (chat_channel->isOpened())
                     {
                         m.status = chat_channel->sendChatMessageWithId(m.text, m.time, m.identifier) ? Sending : Error;
                         attempted = true;
                     }
                     break;
-                case ConversationModel::MessageData::Type::File:
+                case ConversationModel::MessageType::File:
                     if (file_channel->isOpened())
                     {
                         logger::println("Attempted to send queued file: {}", m.text);
@@ -344,7 +343,7 @@ void ConversationModel::messageReceived(const QString &text, const QDateTime &ti
     }
 
     beginInsertRows(QModelIndex(), row, row);
-    MessageData message(text, time, id, Received);
+    MessageData message(Message, text, time, id, Received);
     messages.insert(row, message);
     endInsertRows();
     prune();

--- a/src/libtego/source/core/ConversationModel.h
+++ b/src/libtego/source/core/ConversationModel.h
@@ -60,6 +60,11 @@ public:
         Error
     };
 
+    enum MessageType {
+        Message,
+        File
+    };
+
     ConversationModel(QObject *parent = 0);
 
     ContactUser *contact() const { return m_contact; }
@@ -100,10 +105,7 @@ private slots:
 
 private:
     struct MessageData {
-        enum Type {
-            Message,
-            File
-        } type;
+        MessageType type;
         QString text;
         tego_file_hash_t fileHash;
         QDateTime time;
@@ -111,8 +113,8 @@ private:
         MessageStatus status;
         quint8 attemptCount;
 
-        MessageData(const QString &text, const QDateTime &time, MessageId id, MessageStatus status)
-            : text(text), time(time), identifier(id), status(status), attemptCount(0)
+        MessageData(MessageType type, const QString &text, const QDateTime &time, MessageId id, MessageStatus status)
+            : type(type), text(text), time(time), identifier(id), status(status), attemptCount(0)
         {
         }
     };

--- a/src/libtego_ui/libtego_callbacks.cpp
+++ b/src/libtego_ui/libtego_callbacks.cpp
@@ -375,6 +375,7 @@ namespace
             auto userIdentity = shims::UserIdentity::userIdentity;
             auto contactsManager = userIdentity->getContacts();
             auto contact = contactsManager->getShimContactByContactId(serviceIdToContactId(serviceId));
+            auto conversation = contact->conversation();
 
             if (contact != nullptr)
             {
@@ -383,10 +384,12 @@ namespace
                     case tego_user_status_online:
                         contact->setStatus(shims::ContactUser::Online);
                         contactsManager->setContactStatus(contact, shims::ContactUser::Online);
+                        conversation->setStatus(shims::ContactUser::Online);
                         break;
                     case tego_user_status_offline:
                         contact->setStatus(shims::ContactUser::Offline);
                         contactsManager->setContactStatus(contact, shims::ContactUser::Offline);
+                        conversation->setStatus(shims::ContactUser::Offline);
                         break;
                     default:
                         break;

--- a/src/libtego_ui/precomp.hpp
+++ b/src/libtego_ui/precomp.hpp
@@ -15,6 +15,12 @@
 #include <type_traits>
 #include <cstdint>
 #include <functional>
+#include <fstream>
+#include <iterator>
+
+// fmt
+#include <fmt/format.h>
+#include <fmt/ostream.h>
 
 // Qt
 #include <QClipboard>

--- a/src/libtego_ui/shims/ContactUser.cpp
+++ b/src/libtego_ui/shims/ContactUser.cpp
@@ -101,6 +101,11 @@ namespace shims
         this->conversationModel->sendFile();
     }
 
+    bool ContactUser::exportConversation()
+    {
+        return this->conversationModel->exportConversation();
+    }
+
     std::unique_ptr<tego_user_id_t> ContactUser::toTegoUserId() const
     {
         logger::println("serviceId : {}", this->serviceId);

--- a/src/libtego_ui/shims/ContactUser.h
+++ b/src/libtego_ui/shims/ContactUser.h
@@ -39,6 +39,7 @@ namespace shims
 
         Q_INVOKABLE void deleteContact();
         Q_INVOKABLE void sendFile();
+        Q_INVOKABLE bool exportConversation();
 
         std::unique_ptr<tego_user_id_t> toTegoUserId() const;
 

--- a/src/libtego_ui/shims/ConversationModel.cpp
+++ b/src/libtego_ui/shims/ConversationModel.cpp
@@ -111,6 +111,7 @@ namespace shims
                         switch(message.transferStatus)
                         {
                             case Pending: return tr("Pending");
+                            case Accepted: return tr("Accepted");
                             case Rejected: return tr("Rejected");
                             case InProgress:
                             {
@@ -210,6 +211,7 @@ namespace shims
         this->beginInsertRows(QModelIndex(), 0, 0);
         this->messages.prepend(std::move(md));
         this->endInsertRows();
+        this->addEventFromMessage(indexOfOutgoingMessage(messageId));
     }
 
     void ConversationModel::sendFile()
@@ -260,12 +262,165 @@ namespace shims
                 this->beginInsertRows(QModelIndex(), 0, 0);
                 this->messages.prepend(std::move(md));
                 this->endInsertRows();
+
+                this->addEventFromMessage(indexOfOutgoingMessage(id));
             }
             catch(const std::runtime_error& err)
             {
                 qWarning() << err.what();
             }
         }
+    }
+
+    void ConversationModel::deserializeTextMessageEventToFile(const EventData &event, std::ofstream &ofile) const
+    {
+        auto &md = this->messages[this->messages.size() - event.messageData.reverseIndex];
+        switch (md.status)
+        {
+            case Received:
+                fmt::print(ofile, "[{}] <{}>: {}\n",
+                                    md.time.toString().toStdString(),
+                                    this->contact()->getNickname().toStdString(),
+                                    md.text.toStdString()); break;
+            case Delivered:
+                fmt::print(ofile, "[{}] <{}>: {}\n",
+                                    md.time.toString().toStdString(),
+                                    tr("me").toStdString(),
+                                    md.text.toStdString()); break;
+            default:
+                // messages we sent that weren't delivered
+                fmt::print(ofile, "[{}] <{}> ({}): {}\n",
+                                    md.time.toString().toStdString(),
+                                    tr("me").toStdString(),
+                                    getMessageStatusString(md.status),
+                                    md.text.toStdString()); break;
+        }
+    }
+
+    void ConversationModel::deserializeTransferMessageEventToFile(const EventData &event, std::ofstream &ofile) const
+    {
+        auto &md = this->messages[this->messages.size() - event.transferData.reverseIndex];
+
+        if (md.transferDirection == InvalidDirection)
+            return;
+
+        std::string sender = md.transferDirection == Uploading
+                                    ? tr("me").toStdString()
+                                    : this->contact()->getNickname().toStdString();
+
+        switch (event.transferData.status)
+        {
+            case Pending:           //FALLTHROUGH
+            case Accepted:          //FALLTHROUGH
+            case Rejected:          //FALLTHROUGH
+            case Cancelled:         //FALLTHROUGH
+            case Finished:
+                fmt::print(ofile, "[{}] file '{}' from <{}> (hash: {}, size: {:L} bytes): {}\n",
+                                    event.time.toString().toStdString(),
+                                    md.fileName.toStdString(),
+                                    sender,
+                                    md.fileHash.toStdString(),
+                                    md.fileSize,
+                                    getTransferStatusString(event.transferData.status)); break;
+            case UnknownFailure:    //FALLTHROUGH
+            case BadFileHash:       //FALLTHROUGH
+            case NetworkError:      //FALLTHROUGH
+            case FileSystemError:
+                fmt::print(ofile, "[{}] file '{}' from <{}> (hash: {}, size: {:L} bytes): Error: {}, bytes transferred: {:L} bytes\n",
+                                    event.time.toString().toStdString(),
+                                    md.fileName.toStdString(),
+                                    sender,
+                                    md.fileHash.toStdString(),
+                                    md.fileSize,
+                                    getTransferStatusString(event.transferData.status),
+                                    event.transferData.bytesTransferred); break;
+            default:
+                qWarning() << "Invalid transfer status in events";
+                break;
+        }
+    }
+
+    void ConversationModel::deserializeUserStatusUpdateEventToFile(const EventData &event, std::ofstream &ofile) const
+    {
+        if (event.userStatusData.target == UserTargetNone)
+            return;
+
+        std::string sender = event.userStatusData.target == UserTargetClient
+                                    ? tr("me").toStdString()
+                                    : this->contact()->getNickname().toStdString();
+
+        switch (event.userStatusData.status)
+        {
+            case ContactUser::Status::Online:
+                fmt::print(ofile, "[{}] <{}> is now online\n",
+                                    event.time.toString().toStdString(),
+                                    this->contact()->getNickname().toStdString()); break;
+            case ContactUser::Status::Offline:
+                fmt::print(ofile, "[{}] <{}> is now offline\n",
+                                    event.time.toString().toStdString(),
+                                    this->contact()->getNickname().toStdString()); break;
+            case ContactUser::Status::RequestPending:
+                fmt::print(ofile, "[{}] New contact request to <{}>\n",
+                                    event.time.toString().toStdString(),
+                                    this->contact()->getNickname().toStdString()); break;
+            case ContactUser::Status::RequestRejected:
+                fmt::print(ofile, "[{}] Outgoing request to <{}> was rejected\n",
+                                    event.time.toString().toStdString(),
+                                    this->contact()->getNickname().toStdString()); break;
+            default:
+                break;
+        }
+    }
+
+    void ConversationModel::deserializeEventToFile(const EventData &event, std::ofstream &ofile) const
+    {
+        switch (event.type)
+        {
+            case TextMessageEvent:
+                deserializeTextMessageEventToFile(event, ofile); break;
+            case TransferMessageEvent:
+                deserializeTransferMessageEventToFile(event, ofile); break;
+            case UserStatusUpdateEvent:
+                deserializeUserStatusUpdateEventToFile(event, ofile); break;
+            default:
+                qWarning() << "Unknown event type in events list";
+                break;
+        }
+    }
+
+    bool ConversationModel::hasEventsToExport() {
+        return events.size() > 0;
+    }
+
+    bool ConversationModel::exportConversation()
+    {
+        const auto proposedDest = QString("%1/%2-%3.log").arg(QStandardPaths::writableLocation(QStandardPaths::DownloadLocation)).arg(this->contact()->getNickname()).arg(this->messages.constFirst().time.toString(Qt::ISODate));
+
+        auto filePath = QFileDialog::getSaveFileName(nullptr,
+                                                        tr("Save File"),
+                                                        proposedDest,
+                                                        "Log files (*.log);;All files (*)");
+
+        if (filePath.isEmpty())
+            return true;
+
+        std::ofstream ofile(filePath.toStdString(), std::ios::out);
+        if (!ofile.is_open())
+        {
+            qWarning() << "Could not open file " << filePath;
+            return false;
+        }
+
+        fmt::print(ofile, "Conversation with {} ({})\n",
+                            this->contact()->getNickname().toStdString(),
+                            this->contact()->getContactID().toStdString());
+
+        foreach(auto &event, this->events)
+        {
+            deserializeEventToFile(event, ofile);
+        }
+
+        return true;
     }
 
     void ConversationModel::tryAcceptFileTransfer(quint32 id)
@@ -308,8 +463,9 @@ namespace shims
                 qWarning() << err.what();
             }
 
-            data.transferStatus = Pending;
+            data.transferStatus = Accepted;
             emitDataChanged(row);
+            this->addEventFromMessage(row);
         }
     }
 
@@ -328,6 +484,7 @@ namespace shims
         {
             data.transferStatus = Cancelled;
             emitDataChanged(row);
+            this->addEventFromMessage(row);
 
             auto userIdentity = shims::UserIdentity::userIdentity;
             auto context = userIdentity->getContext();
@@ -380,6 +537,7 @@ namespace shims
 
         data.transferStatus = Rejected;
         emitDataChanged(row);
+        this->addEventFromMessage(row);
     }
 
     void ConversationModel::fileTransferRequestReceived(tego_file_transfer_id_t id, QString fileName, QString fileHash, quint64 fileSize)
@@ -401,6 +559,7 @@ namespace shims
         this->endInsertRows();
 
         this->setUnreadCount(this->unreadCount + 1);
+        this->addEventFromMessage(indexOfIncomingMessage(id));
     }
 
     void ConversationModel::fileTransferRequestAcknowledged(tego_file_transfer_id_t id, bool accepted)
@@ -422,7 +581,7 @@ namespace shims
         switch(response)
         {
             case tego_file_transfer_response_accept:
-                data.transferStatus = Pending;
+                data.transferStatus = Accepted;
                 break;
             case tego_file_transfer_response_reject:
                 data.transferStatus = Rejected;
@@ -432,6 +591,7 @@ namespace shims
         }
 
         emitDataChanged(row);
+        this->addEventFromMessage(row);
     }
 
     void ConversationModel::fileTransferRequestProgressUpdated(tego_file_transfer_id_t id, quint64 bytesTransferred)
@@ -482,6 +642,7 @@ namespace shims
                     break;
             }
             emitDataChanged(row);
+            this->addEventFromMessage(row);
         }
     }
 
@@ -513,6 +674,7 @@ namespace shims
         this->endInsertRows();
 
         this->setUnreadCount(this->unreadCount + 1);
+        this->addEventFromMessage(indexOfIncomingMessage(messageId));
     }
 
     void ConversationModel::messageAcknowledged(tego_message_id_t messageId, bool accepted)
@@ -523,6 +685,48 @@ namespace shims
         MessageData &data = messages[row];
         data.status = accepted ? Delivered : Error;
         emitDataChanged(row);
+    }
+
+    void ConversationModel::addEventFromMessage(int row)
+    {
+        EventData ed;
+
+        if (row < 0)
+            return;
+
+        auto &md = this->messages[row];
+        switch (md.type)
+        {
+            case TextMessage:
+                ed.type = TextMessageEvent;
+                ed.messageData.reverseIndex = this->messages.size() - row;
+                break;
+            case TransferMessage:
+                ed.type = TransferMessageEvent;
+                ed.transferData.reverseIndex = this->messages.size() - row;
+                ed.transferData.status = md.transferStatus;
+                ed.transferData.bytesTransferred = md.bytesTransferred;
+                break;
+            default:
+                return;
+        }
+        ed.time = QDateTime::currentDateTime();
+
+        this->events.append(std::move(ed));
+        emit this->conversationEventCountChanged();
+    }
+
+    void ConversationModel::setStatus(ContactUser::Status status)
+    {
+        EventData ed;
+
+        ed.type = UserStatusUpdateEvent;
+        ed.userStatusData.status = status;
+        ed.userStatusData.target = UserTargetPeer;
+        ed.time = QDateTime::currentDateTime();
+
+        this->events.append(std::move(ed));
+        emit this->conversationEventCountChanged();
     }
 
     void ConversationModel::emitDataChanged(int row)
@@ -562,5 +766,40 @@ namespace shims
                 return i;
         }
         return -1;
+    }
+
+    const char* ConversationModel::getMessageStatusString(const MessageStatus status)
+    {
+        constexpr static const char* statusList[] =
+        {
+            "None",
+            "Received",
+            "Queued",
+            "Sending",
+            "Delivered",
+            "Error"
+        };
+
+        return statusList[static_cast<size_t>(status)];
+    }
+
+    const char* ConversationModel::getTransferStatusString(const TransferStatus status)
+    {
+        constexpr static const char* statusList[] =
+        {
+            "Invalid Transfer",
+            "Pending",
+            "Accepted",
+            "Rejected",
+            "In Progress",
+            "Cancelled",
+            "Finished",
+            "Unknown Failure",
+            "Bad File Hash",
+            "Network Error",
+            "Filesystem Error"
+        };
+
+        return statusList[static_cast<size_t>(status)];
     }
 }

--- a/src/libtego_ui/shims/ConversationModel.h
+++ b/src/libtego_ui/shims/ConversationModel.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "ContactUser.h"
+
 namespace shims
 {
     class ContactUser;
@@ -10,6 +12,7 @@ namespace shims
 
         Q_PROPERTY(shims::ContactUser* contact READ contact WRITE setContact NOTIFY contactChanged)
         Q_PROPERTY(int unreadCount READ getUnreadCount RESET resetUnreadCount NOTIFY unreadCountChanged)
+        Q_PROPERTY(int conversationEventCount READ getConversationEventCount NOTIFY conversationEventCountChanged)
     public:
         ConversationModel(QObject *parent = 0);
 
@@ -43,6 +46,7 @@ namespace shims
         {
             InvalidTransfer,
             Pending,
+            Accepted,
             Rejected,
             InProgress,
             Cancelled,
@@ -62,6 +66,19 @@ namespace shims
         };
         Q_ENUM(TransferDirection);
 
+        enum EventType {
+            InvalidEvent,
+            TextMessageEvent,
+            TransferMessageEvent,
+            UserStatusUpdateEvent
+        };
+
+        enum UserStatusTarget {
+            UserTargetNone,
+            UserTargetClient,
+            UserTargetPeer
+        };
+
         // impl QAbstractListModel
         virtual QHash<int,QByteArray> roleNames() const;
         virtual int rowCount(const QModelIndex &parent = QModelIndex()) const;
@@ -73,11 +90,17 @@ namespace shims
         Q_INVOKABLE void resetUnreadCount();
 
         void sendFile();
+        bool hasEventsToExport();
+        Q_INVOKABLE int getConversationEventCount() const { return this->events.size(); }
+        bool exportConversation();
         // invokable function neeeds to use a Qt type since it is invokable from QML
         static_assert(std::is_same_v<quint32, tego_file_transfer_id_t>);
         Q_INVOKABLE void tryAcceptFileTransfer(quint32 id);
         Q_INVOKABLE void cancelFileTransfer(quint32 id);
         Q_INVOKABLE void rejectFileTransfer(quint32 id);
+
+
+        void setStatus(ContactUser::Status status);
 
         void fileTransferRequestReceived(tego_file_transfer_id_t id, QString fileName, QString fileHash, quint64 fileSize);
         void fileTransferRequestAcknowledged(tego_file_transfer_id_t id, bool accepted);
@@ -95,6 +118,7 @@ namespace shims
     signals:
         void contactChanged();
         void unreadCountChanged(int prevCount, int currentCount);
+        void conversationEventCountChanged();
     private:
         void setUnreadCount(int count);
 
@@ -119,12 +143,48 @@ namespace shims
             TransferStatus transferStatus = InvalidTransfer;
         };
 
+        struct EventData
+        {
+            EventType type = InvalidEvent;
+            union {
+                struct {
+                    size_t reverseIndex = 0;
+                } messageData;
+                struct {
+                    size_t reverseIndex = 0;
+                    TransferStatus status = InvalidTransfer;
+                    qint64 bytesTransferred = 0; // we care about this for when a transfer is cancelled midway 
+                } transferData;
+                struct {
+                    ContactUser::Status status = ContactUser::Status::Offline;
+                    UserStatusTarget target = UserTargetNone; // when the protocol is eventually fixed and users
+                                                              // are notified of being blocked, this will be needed
+                } userStatusData;
+            };
+            QDateTime time = {};
+
+            EventData() {}
+        };
+
         QList<MessageData> messages;
+        QList<EventData> events;
+
+        void addEventFromMessage(int row);
+
+        void deserializeTextMessageEventToFile(const EventData &event, std::ofstream &ofile) const;
+        void deserializeTransferMessageEventToFile(const EventData &event, std::ofstream &ofile) const;
+        void deserializeUserStatusUpdateEventToFile(const EventData &event, std::ofstream &ofile) const;
+        void deserializeEventToFile(const EventData &event, std::ofstream &ofile) const;
+
         int unreadCount = 0;
 
         void emitDataChanged(int row);
+
         int indexOfMessage(quint32 identifier) const;
         int indexOfOutgoingMessage(quint32 identifier) const;
         int indexOfIncomingMessage(quint32 identifier) const;
+
+        static const char* getMessageStatusString(const MessageStatus status);
+        static const char* getTransferStatusString(const TransferStatus status);
     };
 }

--- a/src/libtego_ui/ui/qml/ContactActions.qml
+++ b/src/libtego_ui/ui/qml/ContactActions.qml
@@ -35,7 +35,30 @@ Item {
         contact.sendFile();
     }
 
+    function canExportConversation() {
+        return contact.conversation.conversationEventCount > 0;
+    }
+
+    function exportConversation() {
+        if (contact.exportConversation() != true) {
+            exportConversationFailedDialog.visible = true;
+        }
+    }
+
     signal renameTriggered
+
+    MessageDialog {
+        id: exportConversationFailedDialog
+
+        title: qsTr("Warning")
+        icon: StandardIcon.Warning
+        text: qsTr("Could not successfully export conversation")
+        standardButtons: StandardButton.Ok
+
+        visible: false
+
+        onAccepted: visible = false;
+    }
 
     Menu {
         id: contextMenu
@@ -59,7 +82,13 @@ Item {
         MenuItem {
             //: Context menu command to initiate a file transfer, opens a system file dialog
             text: qsTr("Send File...")
-            onTriggered: sendFile();
+            onTriggered: sendFile()
+        }
+        MenuItem {
+            //: Context menu command to initiate a chat log export, opens a system file dialog to export to
+            enabled: canExportConversation()   // only enable if we have anything to export
+            text: qsTr("Export Conversation...")
+            onTriggered: exportConversation()
         }
         MenuSeparator { }
         MenuItem {

--- a/src/libtego_ui/ui/qml/MessageDelegate.qml
+++ b/src/libtego_ui/ui/qml/MessageDelegate.qml
@@ -161,7 +161,10 @@ Column {
                             width: parent.width
                             height: visible ? 8 : 0
 
-                            visible: model.transfer ? (model.transfer.status === ConversationModel.Pending || model.transfer.status === ConversationModel.InProgress) : false
+                            visible: model.transfer ?
+                                    (model.transfer.status === ConversationModel.Pending ||
+                                     model.transfer.status === ConversationModel.InProgress ||
+                                     model.transfer.status === ConversationModel.Accepted) : false
 
                             indeterminate: model.transfer ? (model.transfer.status === ConversationModel.Pending) : true
                             value: model.transfer ? model.transfer.progressPercent : 0
@@ -239,7 +242,10 @@ Column {
 
                     Button {
                         id: cancelButton
-                        visible: model.transfer ? (model.transfer.status === ConversationModel.Pending || model.transfer.status === ConversationModel.InProgress) : false
+                        visible: model.transfer ?
+                                (model.transfer.status === ConversationModel.Pending ||
+                                 model.transfer.status === ConversationModel.InProgress ||
+                                 model.transfer.status === ConversationModel.Accepted) : false
 
                         width: visible ? transferDisplay.height : 0
                         height: visible ? transferDisplay.height : 0

--- a/src/tego_ui/translation/ricochet_bg.ts
+++ b/src/tego_ui/translation/ricochet_bg.ts
@@ -21,29 +21,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="36"/>
-        <source>Ricochet Refresh web home page</source>
-        <extracomment>provides context for the URL for accessibility tech like screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="59"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="32"/>
         <source>The license of Ricochet Refresh and its dependencies</source>
-        <extracomment>summary of a block of text for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="60"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="33"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="65"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="37"/>
         <source>About</source>
         <translation type="unfinished">За Програмта</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="39"/>
         <source>About page, contains license and version information</source>
         <extracomment>summary of the window&apos;s contents for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -105,37 +98,53 @@
 <context>
     <name>ContactActions</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="49"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <source>Could not successfully export conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="65"/>
         <source>Open Window</source>
         <extracomment>Context menu command to open the chat screen in a separate window</extracomment>
         <translation>Отвори Прозорец</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="70"/>
         <source>Details...</source>
         <extracomment>Context menu command to open a window showing the selected contact&apos;s details</extracomment>
         <translation>Допълнитлно...</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="56"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="75"/>
         <source>Rename</source>
         <extracomment>Context menu command to rename the selected contact</extracomment>
         <translation>Преименувай</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="61"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="80"/>
         <source>Send File...</source>
         <extracomment>Context menu command to initiate a file transfer, opens a system file dialog</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="85"/>
+        <source>Export Conversation</source>
+        <extracomment>Context menu command to initiate a chat log export, opens a system file dialog to export to</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="91"/>
         <source>Remove</source>
         <extracomment>Context menu command to remove a contact from the contact list</extracomment>
         <translation>Премахни</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="74"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="98"/>
         <source>Contact options</source>
         <extracomment>Description of the items in the context menu for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -151,30 +160,36 @@
     </message>
     <message>
         <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="45"/>
+        <source>This ID is invalid</source>
+        <extracomment>Error message showed when the id doesn&apos;t comply with spec https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
         <source>You can&apos;t add yourself as a contact</source>
         <extracomment>Error message showed when user attempts to add themselves as a contact in their contact list</extracomment>
         <translation>Не може да добавиш себе си като контакт</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="55"/>
         <source>Enter an ID starting with &lt;b&gt;ricochet:&lt;/b&gt;</source>
         <extracomment>Error message showed when the provided ricochet id is invalid</extracomment>
         <translation>Въведи Идентификатор с &lt;b&gt;рикошет:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="88"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="97"/>
         <source>Copied to clipboard</source>
         <extracomment>Message displayed when text is copied to the user&apos;s clipboard</extracomment>
         <translation>Копирано</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="103"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="112"/>
         <source>Copy</source>
         <extracomment>Text displayed on a button used to copy somethign to the user&apos;s clipboard</extracomment>
         <translation>Копирай</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="119"/>
         <source>Copies the ricochet id to the clipboard</source>
         <extracomment>Text description of ricochet id copy button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -397,20 +412,19 @@
         <translation>Използвай само един прозорец за всички разговори</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Open links in default browser without prompting</source>
         <extracomment>Text description of an option to open URLs in default web browser when clicked</extracomment>
-        <translation>Отваряй връзките в браузъра по подразбиране без да искаш разрешение</translation>
+        <translation type="vanished">Отваряй връзките в браузъра по подразбиране без да искаш разрешение</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="44"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Play audio notifications</source>
         <extracomment>Text description of an option to play audio notifications when contacts log in, log out, and send messages</extracomment>
         <translation>Използвай звукови известия</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="61"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="77"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="62"/>
         <source>Volume</source>
         <extracomment>Label for a slider used to adjust audio notification volume
 ----------
@@ -418,8 +432,8 @@ Name of the slider used to adjust audio notification volume for accessibility te
         <translation>Звук</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="91"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="129"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="114"/>
         <source>Language</source>
         <extracomment>Label for combobox where users can specify the UI language
 ----------
@@ -427,12 +441,12 @@ Name of the combobox used to select UI langauge for accessibility tech like scre
         <translation type="unfinished">Език</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="117"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="102"/>
         <source>Restart Ricochet to apply changes</source>
         <translation type="unfinished">Рестартирай Richchet, за да приложиш промените</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="131"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="116"/>
         <source>What language ricochet will use</source>
         <extracomment>Description of what the language combox is for for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -507,17 +521,17 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="157"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="151"/>
         <source>Version Seperator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="191"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="185"/>
         <source>Remove %1</source>
         <translation>Премахни %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="192"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="186"/>
         <source>Do you want to permanently remove %1?</source>
         <translation>Наистина ли искаш да премахнеш %1 завинаги?</translation>
     </message>
@@ -549,79 +563,74 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>%1 е отписан</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="169"/>
         <source>File transfer file name</source>
         <extracomment>Description of the text displaying the filename of a file transfer, used by accessibility tech like screen readres</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="195"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="185"/>
         <source>File transfer progress</source>
         <extracomment>Description of progress bar displaying the file transfer progress, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="210"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="200"/>
         <source>File transfer status</source>
         <extracomment>Description of label displaying the current status of a file transfer, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="225"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="215"/>
         <source>Download</source>
         <extracomment>Label for file transfer &apos;Download&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="227"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="217"/>
         <source>Download file</source>
         <extracomment>Description of what the file transfer &apos;Download&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="244"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="234"/>
         <source>Cancel or reject</source>
         <extracomment>Label for file transfer &apos;Cancel&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="246"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="236"/>
         <source>Cancels or rejects a file transfer</source>
         <extracomment>Description of what the file transfer &apos;Cancel&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="310"/>
         <source>Copy ID</source>
         <extracomment>Text for context menu command to copy a ricochet contact id to clipboard</extracomment>
-        <translation>Копирай Идентификатора</translation>
+        <translation type="vanished">Копирай Идентификатора</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="281"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="312"/>
         <source>Copy Link</source>
         <extracomment>Text for context menu command to copy a url to the clipboard</extracomment>
-        <translation>Копирай Връзката</translation>
+        <translation type="vanished">Копирай Връзката</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="287"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="318"/>
         <source>Open with Browser</source>
         <extracomment>Text for context menu command to open a url in a web browser</extracomment>
-        <translation>Отвори в Браузъра</translation>
+        <translation type="vanished">Отвори в Браузъра</translation>
     </message>
     <message>
         <source>Add as Contact</source>
         <translation type="vanished">Доабви като Контакт</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="335"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="262"/>
         <source>Copy Message</source>
         <extracomment>Text for context menu command to copy an entire message to clipboard</extracomment>
         <translation>Копирай съобщение</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="343"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="270"/>
         <source>Copy Selection</source>
         <extracomment>Text for context menu command to copy selected text to clipboard</extracomment>
         <translation>Копирай селекцията</translation>
@@ -705,38 +714,28 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>OpenBrowserDialog</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="41"/>
         <source>&lt;b&gt;Warning!&lt;/b&gt; Opening links with your default browser will harm your security and anonymity.&lt;br&gt;&lt;br&gt;You can &lt;a href=&apos;.&apos;&gt;copy to the clipboard&lt;/a&gt; instead.</source>
         <extracomment>Label displayed when user clicks on a link</extracomment>
-        <translation>&lt;b&gt;Внимание!&lt;/b&gt; Отварянето на връзки с браузъра по подразбиране може да прекрати сигурната и анонимността ти.&lt;br&gt;&lt;br&gt;Вместо това може да го &lt;a href=&apos;.&apos;&gt;копираш&lt;/a&gt;.</translation>
+        <translation type="vanished">&lt;b&gt;Внимание!&lt;/b&gt; Отварянето на връзки с браузъра по подразбиране може да прекрати сигурната и анонимността ти.&lt;br&gt;&lt;br&gt;Вместо това може да го &lt;a href=&apos;.&apos;&gt;копираш&lt;/a&gt;.</translation>
     </message>
     <message>
         <source>Don&apos;t ask again for links from %1</source>
         <translation type="vanished">Не искай повече връзки от %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="50"/>
-        <source>Warning</source>
-        <extracomment>Name of warning label used with accessibility tech such as screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="65"/>
         <source>Don&apos;t ask again for any links (not recommended!)</source>
         <extracomment>Checkbox option text for when user clicks on a link</extracomment>
-        <translation>Не искай повече никакви връзки (не се препоръчва!)</translation>
+        <translation type="vanished">Не искай повече никакви връзки (не се препоръчва!)</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="73"/>
         <source>Open Browser</source>
         <extracomment>Label on button to open link in a web browser</extracomment>
-        <translation>Отвори Браузъра</translation>
+        <translation type="vanished">Отвори Браузъра</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="84"/>
         <source>Cancel</source>
         <extracomment>Label on cancel button</extracomment>
-        <translation>Откажи</translation>
+        <translation type="vanished">Откажи</translation>
     </message>
 </context>
 <context>
@@ -878,144 +877,144 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>Този компютър нуждае ли се от прокси, за да се свърже с интернет?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="69"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="70"/>
         <source>Proxy type:</source>
         <translation>Вид Прокси:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="74"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="75"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="77"/>
         <source>None</source>
         <translation>Никакво</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="92"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="93"/>
         <source>If you need a proxy to access the internet, select one from this list.</source>
         <extracomment>Description used by accessibility tech, such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="97"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="98"/>
         <source>Address:</source>
         <extracomment>Label indicating the textbox to place a proxy IP or URL</extracomment>
         <translation>Адрес:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="111"/>
         <source>IP address or hostname</source>
         <extracomment>Placeholder text of text box expecting an IP or URL for proxy</extracomment>
         <translation>IP адрес или hostname</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="115"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="116"/>
         <source>Enter the IP address or hostname of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the IP textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="119"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="120"/>
         <source>Port:</source>
         <extracomment>Label indicating the textbox to place a proxy port</extracomment>
         <translation>Порт:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="130"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="131"/>
         <source>Port</source>
         <extracomment>Name of the port label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="132"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="133"/>
         <source>Enter the port of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the Port textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="138"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="139"/>
         <source>Username:</source>
         <extracomment>Label indicating the textbox to place the proxy username</extracomment>
         <translation>Потребителско Име:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="152"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="173"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="153"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="174"/>
         <source>Optional</source>
         <extracomment>Textbox placeholder text indicating the field is not required</extracomment>
         <translation>Незадължително</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="156"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="157"/>
         <source>Username</source>
         <extracomment>Name of the username label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="158"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="159"/>
         <source>If required, enter the username for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Username textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="162"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="163"/>
         <source>Password:</source>
         <extracomment>Label indicating the textbox to place the proxy password</extracomment>
         <translation>Парола:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="177"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="178"/>
         <source>Password</source>
         <extracomment>Name of the password label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="180"/>
         <source>If required, enter the password for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Password textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="190"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="191"/>
         <source>Does this computer&apos;s Internet connection go through a firewall that only allows connections to certain ports?</source>
         <extracomment>Description for the purpose of the Allowed Ports textbox</extracomment>
         <translation>Минава ли интернет връзката на този компютър през firewall програма, която позволява връзка само през определени портове?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="211"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="212"/>
         <source>Allowed ports:</source>
         <extracomment>Label indicating the textbox to place the allowed ports</extracomment>
         <translation>Разрешени портове:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="220"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="221"/>
         <source>Example: 80,443</source>
         <extracomment>Textbox showing an example entry for the firewall allowed ports entry</extracomment>
         <translation>Пример: 80,443</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="224"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="225"/>
         <source>Allowed ports</source>
         <extracomment>Name of the allowed ports label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="236"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="237"/>
         <source>If this computer&apos;s Internet connection is censored, you will need to obtain and use bridge relays.</source>
         <translation>Ако интернет връзката на този компютър е цензурирана, ще се наложи да намериш и използваш bridge relays.</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="251"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="262"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="252"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="263"/>
         <source>Enter one or more bridge relays (one per line):</source>
         <translation>Въведи едно или повече bridge relays (по едно на ред):</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="273"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="274"/>
         <source>Back</source>
         <extracomment>Button label for going back to previous screen</extracomment>
         <translation>Назад</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="284"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="285"/>
         <source>Connect</source>
         <extracomment>Button label for connecting to tor</extracomment>
         <translation>Свържи</translation>
@@ -1192,51 +1191,65 @@ Name of the button for launching the preferences window for accessibility tech l
     </message>
     <message>
         <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="114"/>
+        <source>Accepted</source>
+        <translation type="unfinished">Прието</translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="115"/>
         <source>Rejected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="120"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
         <source>Cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
         <source>Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
         <source>Unkown Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
         <source>Bad File Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
         <source>Network Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="126"/>
         <source>File System Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="127"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="128"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="220"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="223"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="395"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="285"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="289"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="295"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="309"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="350"/>
+        <source>me</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="436"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/tego_ui/translation/ricochet_cs.ts
+++ b/src/tego_ui/translation/ricochet_cs.ts
@@ -21,29 +21,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="36"/>
-        <source>Ricochet Refresh web home page</source>
-        <extracomment>provides context for the URL for accessibility tech like screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="59"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="32"/>
         <source>The license of Ricochet Refresh and its dependencies</source>
-        <extracomment>summary of a block of text for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="60"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="33"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="65"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="37"/>
         <source>About</source>
         <translation type="unfinished">O programu</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="39"/>
         <source>About page, contains license and version information</source>
         <extracomment>summary of the window&apos;s contents for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -105,37 +98,53 @@
 <context>
     <name>ContactActions</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="49"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <source>Could not successfully export conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="65"/>
         <source>Open Window</source>
         <extracomment>Context menu command to open the chat screen in a separate window</extracomment>
         <translation>Otevřít okno</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="70"/>
         <source>Details...</source>
         <extracomment>Context menu command to open a window showing the selected contact&apos;s details</extracomment>
         <translation>Podrobnosti...</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="56"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="75"/>
         <source>Rename</source>
         <extracomment>Context menu command to rename the selected contact</extracomment>
         <translation>Přejmenovat</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="61"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="80"/>
         <source>Send File...</source>
         <extracomment>Context menu command to initiate a file transfer, opens a system file dialog</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="85"/>
+        <source>Export Conversation</source>
+        <extracomment>Context menu command to initiate a chat log export, opens a system file dialog to export to</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="91"/>
         <source>Remove</source>
         <extracomment>Context menu command to remove a contact from the contact list</extracomment>
         <translation>Odstranit</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="74"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="98"/>
         <source>Contact options</source>
         <extracomment>Description of the items in the context menu for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -151,30 +160,36 @@
     </message>
     <message>
         <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="45"/>
+        <source>This ID is invalid</source>
+        <extracomment>Error message showed when the id doesn&apos;t comply with spec https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
         <source>You can&apos;t add yourself as a contact</source>
         <extracomment>Error message showed when user attempts to add themselves as a contact in their contact list</extracomment>
         <translation>Nelze přidat vlastní adresu na seznam kontaktů</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="55"/>
         <source>Enter an ID starting with &lt;b&gt;ricochet:&lt;/b&gt;</source>
         <extracomment>Error message showed when the provided ricochet id is invalid</extracomment>
         <translation>Zadejte ID začínající slovem &lt;b&gt;ricochet:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="88"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="97"/>
         <source>Copied to clipboard</source>
         <extracomment>Message displayed when text is copied to the user&apos;s clipboard</extracomment>
         <translation>Zkopírováno do schránky</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="103"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="112"/>
         <source>Copy</source>
         <extracomment>Text displayed on a button used to copy somethign to the user&apos;s clipboard</extracomment>
         <translation>Zkopírovat</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="119"/>
         <source>Copies the ricochet id to the clipboard</source>
         <extracomment>Text description of ricochet id copy button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -397,20 +412,19 @@
         <translation>Používat totéž okno pro všechny konverzace</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Open links in default browser without prompting</source>
         <extracomment>Text description of an option to open URLs in default web browser when clicked</extracomment>
-        <translation>Otevírat odkazy v defaultním prohlížeči bez dotazování</translation>
+        <translation type="vanished">Otevírat odkazy v defaultním prohlížeči bez dotazování</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="44"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Play audio notifications</source>
         <extracomment>Text description of an option to play audio notifications when contacts log in, log out, and send messages</extracomment>
         <translation>Povolit zvukové upozornění</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="61"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="77"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="62"/>
         <source>Volume</source>
         <extracomment>Label for a slider used to adjust audio notification volume
 ----------
@@ -418,8 +432,8 @@ Name of the slider used to adjust audio notification volume for accessibility te
         <translation>Hlasitost</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="91"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="129"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="114"/>
         <source>Language</source>
         <extracomment>Label for combobox where users can specify the UI language
 ----------
@@ -427,12 +441,12 @@ Name of the combobox used to select UI langauge for accessibility tech like scre
         <translation type="unfinished">Jazyk</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="117"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="102"/>
         <source>Restart Ricochet to apply changes</source>
         <translation type="unfinished">Restartovat Ricochet aby se změny projevily</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="131"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="116"/>
         <source>What language ricochet will use</source>
         <extracomment>Description of what the language combox is for for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -507,17 +521,17 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="157"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="151"/>
         <source>Version Seperator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="191"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="185"/>
         <source>Remove %1</source>
         <translation>Odstranit %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="192"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="186"/>
         <source>Do you want to permanently remove %1?</source>
         <translation>Chcete trvale odstranit kontakt %1?</translation>
     </message>
@@ -549,79 +563,74 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>%1 je offline</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="169"/>
         <source>File transfer file name</source>
         <extracomment>Description of the text displaying the filename of a file transfer, used by accessibility tech like screen readres</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="195"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="185"/>
         <source>File transfer progress</source>
         <extracomment>Description of progress bar displaying the file transfer progress, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="210"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="200"/>
         <source>File transfer status</source>
         <extracomment>Description of label displaying the current status of a file transfer, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="225"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="215"/>
         <source>Download</source>
         <extracomment>Label for file transfer &apos;Download&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="227"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="217"/>
         <source>Download file</source>
         <extracomment>Description of what the file transfer &apos;Download&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="244"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="234"/>
         <source>Cancel or reject</source>
         <extracomment>Label for file transfer &apos;Cancel&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="246"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="236"/>
         <source>Cancels or rejects a file transfer</source>
         <extracomment>Description of what the file transfer &apos;Cancel&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="310"/>
         <source>Copy ID</source>
         <extracomment>Text for context menu command to copy a ricochet contact id to clipboard</extracomment>
-        <translation>Kopírovat ID</translation>
+        <translation type="vanished">Kopírovat ID</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="281"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="312"/>
         <source>Copy Link</source>
         <extracomment>Text for context menu command to copy a url to the clipboard</extracomment>
-        <translation>Kopírovat odkaz</translation>
+        <translation type="vanished">Kopírovat odkaz</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="287"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="318"/>
         <source>Open with Browser</source>
         <extracomment>Text for context menu command to open a url in a web browser</extracomment>
-        <translation>Otevřít v prohlížeči</translation>
+        <translation type="vanished">Otevřít v prohlížeči</translation>
     </message>
     <message>
         <source>Add as Contact</source>
         <translation type="vanished">Přidat jako kontakt</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="335"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="262"/>
         <source>Copy Message</source>
         <extracomment>Text for context menu command to copy an entire message to clipboard</extracomment>
         <translation>Kopírovat zprávu</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="343"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="270"/>
         <source>Copy Selection</source>
         <extracomment>Text for context menu command to copy selected text to clipboard</extracomment>
         <translation>Kopírovat výběr</translation>
@@ -705,38 +714,28 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>OpenBrowserDialog</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="41"/>
         <source>&lt;b&gt;Warning!&lt;/b&gt; Opening links with your default browser will harm your security and anonymity.&lt;br&gt;&lt;br&gt;You can &lt;a href=&apos;.&apos;&gt;copy to the clipboard&lt;/a&gt; instead.</source>
         <extracomment>Label displayed when user clicks on a link</extracomment>
-        <translation>&lt;b&gt;-Upozornění!&lt;/b&gt; Otvírání odkazů v defaultním prohlížeči naruší vaši bezpečnost a anonymitu.&lt;br&gt;&lt;br&gt;Můžete místo toho odkaz &lt;a href=&apos;.&apos;&gt;zkopírovat do schránky&lt;/a&gt;.</translation>
+        <translation type="vanished">&lt;b&gt;-Upozornění!&lt;/b&gt; Otvírání odkazů v defaultním prohlížeči naruší vaši bezpečnost a anonymitu.&lt;br&gt;&lt;br&gt;Můžete místo toho odkaz &lt;a href=&apos;.&apos;&gt;zkopírovat do schránky&lt;/a&gt;.</translation>
     </message>
     <message>
         <source>Don&apos;t ask again for links from %1</source>
         <translation type="vanished">Znovu nepožadovat odkazy od kontaktu %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="50"/>
-        <source>Warning</source>
-        <extracomment>Name of warning label used with accessibility tech such as screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="65"/>
         <source>Don&apos;t ask again for any links (not recommended!)</source>
         <extracomment>Checkbox option text for when user clicks on a link</extracomment>
-        <translation>Znovu nepožadovat žádné odkazy (nedoporučuje se!)</translation>
+        <translation type="vanished">Znovu nepožadovat žádné odkazy (nedoporučuje se!)</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="73"/>
         <source>Open Browser</source>
         <extracomment>Label on button to open link in a web browser</extracomment>
-        <translation>Otevřít prohlížeč</translation>
+        <translation type="vanished">Otevřít prohlížeč</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="84"/>
         <source>Cancel</source>
         <extracomment>Label on cancel button</extracomment>
-        <translation>Zrušit</translation>
+        <translation type="vanished">Zrušit</translation>
     </message>
 </context>
 <context>
@@ -878,144 +877,144 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>Potřebuje tento počítač pro přístup na internet proxy?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="69"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="70"/>
         <source>Proxy type:</source>
         <translation>Typ proxy:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="74"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="75"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="77"/>
         <source>None</source>
         <translation>Žádný</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="92"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="93"/>
         <source>If you need a proxy to access the internet, select one from this list.</source>
         <extracomment>Description used by accessibility tech, such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="97"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="98"/>
         <source>Address:</source>
         <extracomment>Label indicating the textbox to place a proxy IP or URL</extracomment>
         <translation>Adresa:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="111"/>
         <source>IP address or hostname</source>
         <extracomment>Placeholder text of text box expecting an IP or URL for proxy</extracomment>
         <translation>IP adresa nebo hostname</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="115"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="116"/>
         <source>Enter the IP address or hostname of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the IP textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="119"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="120"/>
         <source>Port:</source>
         <extracomment>Label indicating the textbox to place a proxy port</extracomment>
         <translation>Port:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="130"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="131"/>
         <source>Port</source>
         <extracomment>Name of the port label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="132"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="133"/>
         <source>Enter the port of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the Port textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="138"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="139"/>
         <source>Username:</source>
         <extracomment>Label indicating the textbox to place the proxy username</extracomment>
         <translation>Username:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="152"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="173"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="153"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="174"/>
         <source>Optional</source>
         <extracomment>Textbox placeholder text indicating the field is not required</extracomment>
         <translation>Volitelné</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="156"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="157"/>
         <source>Username</source>
         <extracomment>Name of the username label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="158"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="159"/>
         <source>If required, enter the username for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Username textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="162"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="163"/>
         <source>Password:</source>
         <extracomment>Label indicating the textbox to place the proxy password</extracomment>
         <translation>Heslo:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="177"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="178"/>
         <source>Password</source>
         <extracomment>Name of the password label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="180"/>
         <source>If required, enter the password for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Password textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="190"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="191"/>
         <source>Does this computer&apos;s Internet connection go through a firewall that only allows connections to certain ports?</source>
         <extracomment>Description for the purpose of the Allowed Ports textbox</extracomment>
         <translation>Prochází připojení tohoto počítače na internet přes firewall, jenž umožňuje připojení pouze na určité porty?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="211"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="212"/>
         <source>Allowed ports:</source>
         <extracomment>Label indicating the textbox to place the allowed ports</extracomment>
         <translation>Povolené porty:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="220"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="221"/>
         <source>Example: 80,443</source>
         <extracomment>Textbox showing an example entry for the firewall allowed ports entry</extracomment>
         <translation>Příklad: 80,443</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="224"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="225"/>
         <source>Allowed ports</source>
         <extracomment>Name of the allowed ports label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="236"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="237"/>
         <source>If this computer&apos;s Internet connection is censored, you will need to obtain and use bridge relays.</source>
         <translation>Je-li připojení tohoto počítače na internet cenzurováno, potřebujete získat a používat bridge relays.</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="251"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="262"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="252"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="263"/>
         <source>Enter one or more bridge relays (one per line):</source>
         <translation>Zadejte jeden či více bridge relays (na jednotlivé řádky):</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="273"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="274"/>
         <source>Back</source>
         <extracomment>Button label for going back to previous screen</extracomment>
         <translation>Zpět</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="284"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="285"/>
         <source>Connect</source>
         <extracomment>Button label for connecting to tor</extracomment>
         <translation>Připojit</translation>
@@ -1192,51 +1191,65 @@ Name of the button for launching the preferences window for accessibility tech l
     </message>
     <message>
         <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="114"/>
+        <source>Accepted</source>
+        <translation type="unfinished">Přijato</translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="115"/>
         <source>Rejected</source>
         <translation type="unfinished">Zamítnuto</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="120"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
         <source>Cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
         <source>Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
         <source>Unkown Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
         <source>Bad File Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
         <source>Network Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="126"/>
         <source>File System Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="127"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="128"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="220"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="223"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="395"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="285"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="289"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="295"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="309"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="350"/>
+        <source>me</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="436"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/tego_ui/translation/ricochet_da.ts
+++ b/src/tego_ui/translation/ricochet_da.ts
@@ -21,29 +21,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="36"/>
-        <source>Ricochet Refresh web home page</source>
-        <extracomment>provides context for the URL for accessibility tech like screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="59"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="32"/>
         <source>The license of Ricochet Refresh and its dependencies</source>
-        <extracomment>summary of a block of text for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="60"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="33"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="65"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="37"/>
         <source>About</source>
         <translation type="unfinished">Om</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="39"/>
         <source>About page, contains license and version information</source>
         <extracomment>summary of the window&apos;s contents for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -105,37 +98,53 @@
 <context>
     <name>ContactActions</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="49"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <source>Could not successfully export conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="65"/>
         <source>Open Window</source>
         <extracomment>Context menu command to open the chat screen in a separate window</extracomment>
         <translation>Åbn Vindue</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="70"/>
         <source>Details...</source>
         <extracomment>Context menu command to open a window showing the selected contact&apos;s details</extracomment>
         <translation>Detaljer...</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="56"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="75"/>
         <source>Rename</source>
         <extracomment>Context menu command to rename the selected contact</extracomment>
         <translation>Omdøb</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="61"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="80"/>
         <source>Send File...</source>
         <extracomment>Context menu command to initiate a file transfer, opens a system file dialog</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="85"/>
+        <source>Export Conversation</source>
+        <extracomment>Context menu command to initiate a chat log export, opens a system file dialog to export to</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="91"/>
         <source>Remove</source>
         <extracomment>Context menu command to remove a contact from the contact list</extracomment>
         <translation>Fjern</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="74"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="98"/>
         <source>Contact options</source>
         <extracomment>Description of the items in the context menu for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -151,30 +160,36 @@
     </message>
     <message>
         <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="45"/>
+        <source>This ID is invalid</source>
+        <extracomment>Error message showed when the id doesn&apos;t comply with spec https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
         <source>You can&apos;t add yourself as a contact</source>
         <extracomment>Error message showed when user attempts to add themselves as a contact in their contact list</extracomment>
         <translation>Du kan ikke tilføje dig selv som kontaktperson</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="55"/>
         <source>Enter an ID starting with &lt;b&gt;ricochet:&lt;/b&gt;</source>
         <extracomment>Error message showed when the provided ricochet id is invalid</extracomment>
         <translation>Skriv et ID der begynder med &lt;b&gt;ricochet:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="88"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="97"/>
         <source>Copied to clipboard</source>
         <extracomment>Message displayed when text is copied to the user&apos;s clipboard</extracomment>
         <translation>Kopieret til clipboardet</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="103"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="112"/>
         <source>Copy</source>
         <extracomment>Text displayed on a button used to copy somethign to the user&apos;s clipboard</extracomment>
         <translation>Kopiér</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="119"/>
         <source>Copies the ricochet id to the clipboard</source>
         <extracomment>Text description of ricochet id copy button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -397,20 +412,19 @@
         <translation>Hold samtaler i ét vindue</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Open links in default browser without prompting</source>
         <extracomment>Text description of an option to open URLs in default web browser when clicked</extracomment>
-        <translation>Åbn links i browser uden at spørge</translation>
+        <translation type="vanished">Åbn links i browser uden at spørge</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="44"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Play audio notifications</source>
         <extracomment>Text description of an option to play audio notifications when contacts log in, log out, and send messages</extracomment>
         <translation>Afspil lydnotifikationer</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="61"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="77"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="62"/>
         <source>Volume</source>
         <extracomment>Label for a slider used to adjust audio notification volume
 ----------
@@ -418,8 +432,8 @@ Name of the slider used to adjust audio notification volume for accessibility te
         <translation>Lydstyrke</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="91"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="129"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="114"/>
         <source>Language</source>
         <extracomment>Label for combobox where users can specify the UI language
 ----------
@@ -427,12 +441,12 @@ Name of the combobox used to select UI langauge for accessibility tech like scre
         <translation type="unfinished">Sprog</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="117"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="102"/>
         <source>Restart Ricochet to apply changes</source>
         <translation type="unfinished">Genstart Ricochet for at anvende nye indstillinger</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="131"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="116"/>
         <source>What language ricochet will use</source>
         <extracomment>Description of what the language combox is for for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -507,17 +521,17 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="157"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="151"/>
         <source>Version Seperator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="191"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="185"/>
         <source>Remove %1</source>
         <translation>Fjern %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="192"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="186"/>
         <source>Do you want to permanently remove %1?</source>
         <translation>Vil du fjerne %1 permanent?</translation>
     </message>
@@ -549,79 +563,74 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>%1 er offline</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="169"/>
         <source>File transfer file name</source>
         <extracomment>Description of the text displaying the filename of a file transfer, used by accessibility tech like screen readres</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="195"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="185"/>
         <source>File transfer progress</source>
         <extracomment>Description of progress bar displaying the file transfer progress, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="210"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="200"/>
         <source>File transfer status</source>
         <extracomment>Description of label displaying the current status of a file transfer, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="225"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="215"/>
         <source>Download</source>
         <extracomment>Label for file transfer &apos;Download&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="227"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="217"/>
         <source>Download file</source>
         <extracomment>Description of what the file transfer &apos;Download&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="244"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="234"/>
         <source>Cancel or reject</source>
         <extracomment>Label for file transfer &apos;Cancel&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="246"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="236"/>
         <source>Cancels or rejects a file transfer</source>
         <extracomment>Description of what the file transfer &apos;Cancel&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="310"/>
         <source>Copy ID</source>
         <extracomment>Text for context menu command to copy a ricochet contact id to clipboard</extracomment>
-        <translation>Kopiér ID</translation>
+        <translation type="vanished">Kopiér ID</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="281"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="312"/>
         <source>Copy Link</source>
         <extracomment>Text for context menu command to copy a url to the clipboard</extracomment>
-        <translation>Kopiér Link</translation>
+        <translation type="vanished">Kopiér Link</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="287"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="318"/>
         <source>Open with Browser</source>
         <extracomment>Text for context menu command to open a url in a web browser</extracomment>
-        <translation>Åbn i browser</translation>
+        <translation type="vanished">Åbn i browser</translation>
     </message>
     <message>
         <source>Add as Contact</source>
         <translation type="vanished">Tilføj som kontaktperson</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="335"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="262"/>
         <source>Copy Message</source>
         <extracomment>Text for context menu command to copy an entire message to clipboard</extracomment>
         <translation>Kopiér besked</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="343"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="270"/>
         <source>Copy Selection</source>
         <extracomment>Text for context menu command to copy selected text to clipboard</extracomment>
         <translation>Kopiér markeret tekst</translation>
@@ -705,38 +714,28 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>OpenBrowserDialog</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="41"/>
         <source>&lt;b&gt;Warning!&lt;/b&gt; Opening links with your default browser will harm your security and anonymity.&lt;br&gt;&lt;br&gt;You can &lt;a href=&apos;.&apos;&gt;copy to the clipboard&lt;/a&gt; instead.</source>
         <extracomment>Label displayed when user clicks on a link</extracomment>
-        <translation>&lt;b&gt;Advarsel!&lt;/b&gt; Ved at åbne links med din browser kan du forringe din sikkerhed og anonymitet.&lt;br&gt;&lt;br&gt;Du kan &lt;a href=&apos;.&apos;&gt;kopiere adressen til clipboardet&lt;/a&gt; i stedet.</translation>
+        <translation type="vanished">&lt;b&gt;Advarsel!&lt;/b&gt; Ved at åbne links med din browser kan du forringe din sikkerhed og anonymitet.&lt;br&gt;&lt;br&gt;Du kan &lt;a href=&apos;.&apos;&gt;kopiere adressen til clipboardet&lt;/a&gt; i stedet.</translation>
     </message>
     <message>
         <source>Don&apos;t ask again for links from %1</source>
         <translation type="vanished">Spørg ikke igen om links fra %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="50"/>
-        <source>Warning</source>
-        <extracomment>Name of warning label used with accessibility tech such as screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="65"/>
         <source>Don&apos;t ask again for any links (not recommended!)</source>
         <extracomment>Checkbox option text for when user clicks on a link</extracomment>
-        <translation>Spørg ikke om nogen links (ikke anbefalt!)</translation>
+        <translation type="vanished">Spørg ikke om nogen links (ikke anbefalt!)</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="73"/>
         <source>Open Browser</source>
         <extracomment>Label on button to open link in a web browser</extracomment>
-        <translation>Åbn Browser</translation>
+        <translation type="vanished">Åbn Browser</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="84"/>
         <source>Cancel</source>
         <extracomment>Label on cancel button</extracomment>
-        <translation>Annullér</translation>
+        <translation type="vanished">Annullér</translation>
     </message>
 </context>
 <context>
@@ -878,144 +877,144 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>Skal denne computer forbinde gennem en proxy for at tilgå internettet?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="69"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="70"/>
         <source>Proxy type:</source>
         <translation>Proxy type:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="74"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="75"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="77"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="92"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="93"/>
         <source>If you need a proxy to access the internet, select one from this list.</source>
         <extracomment>Description used by accessibility tech, such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="97"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="98"/>
         <source>Address:</source>
         <extracomment>Label indicating the textbox to place a proxy IP or URL</extracomment>
         <translation>Adresse:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="111"/>
         <source>IP address or hostname</source>
         <extracomment>Placeholder text of text box expecting an IP or URL for proxy</extracomment>
         <translation>IP-adresse eller værtsnavn</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="115"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="116"/>
         <source>Enter the IP address or hostname of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the IP textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="119"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="120"/>
         <source>Port:</source>
         <extracomment>Label indicating the textbox to place a proxy port</extracomment>
         <translation>Port:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="130"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="131"/>
         <source>Port</source>
         <extracomment>Name of the port label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="132"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="133"/>
         <source>Enter the port of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the Port textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="138"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="139"/>
         <source>Username:</source>
         <extracomment>Label indicating the textbox to place the proxy username</extracomment>
         <translation>Brugernavn:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="152"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="173"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="153"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="174"/>
         <source>Optional</source>
         <extracomment>Textbox placeholder text indicating the field is not required</extracomment>
         <translation>Valgfrit</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="156"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="157"/>
         <source>Username</source>
         <extracomment>Name of the username label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="158"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="159"/>
         <source>If required, enter the username for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Username textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="162"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="163"/>
         <source>Password:</source>
         <extracomment>Label indicating the textbox to place the proxy password</extracomment>
         <translation>Adgangskode:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="177"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="178"/>
         <source>Password</source>
         <extracomment>Name of the password label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="180"/>
         <source>If required, enter the password for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Password textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="190"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="191"/>
         <source>Does this computer&apos;s Internet connection go through a firewall that only allows connections to certain ports?</source>
         <extracomment>Description for the purpose of the Allowed Ports textbox</extracomment>
         <translation>Går denne computers internetforbindelse gennem en firewall der kun tillader forbindelser på visse porte?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="211"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="212"/>
         <source>Allowed ports:</source>
         <extracomment>Label indicating the textbox to place the allowed ports</extracomment>
         <translation>Tilladte porte:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="220"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="221"/>
         <source>Example: 80,443</source>
         <extracomment>Textbox showing an example entry for the firewall allowed ports entry</extracomment>
         <translation>Eksempel: 80,443</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="224"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="225"/>
         <source>Allowed ports</source>
         <extracomment>Name of the allowed ports label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="236"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="237"/>
         <source>If this computer&apos;s Internet connection is censored, you will need to obtain and use bridge relays.</source>
         <translation>Hvis denne computers internetforbindelse er censureret, er du nødt til at finde og benytte bridge relæer.</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="251"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="262"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="252"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="263"/>
         <source>Enter one or more bridge relays (one per line):</source>
         <translation>Indsæt én eller flere bridgerelæer (én per linje):</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="273"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="274"/>
         <source>Back</source>
         <extracomment>Button label for going back to previous screen</extracomment>
         <translation>Tilbage</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="284"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="285"/>
         <source>Connect</source>
         <extracomment>Button label for connecting to tor</extracomment>
         <translation>Forbind</translation>
@@ -1192,51 +1191,65 @@ Name of the button for launching the preferences window for accessibility tech l
     </message>
     <message>
         <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="114"/>
+        <source>Accepted</source>
+        <translation type="unfinished">Accepteret</translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="115"/>
         <source>Rejected</source>
         <translation type="unfinished">Afvist</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="120"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
         <source>Cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
         <source>Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
         <source>Unkown Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
         <source>Bad File Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
         <source>Network Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="126"/>
         <source>File System Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="127"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="128"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="220"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="223"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="395"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="285"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="289"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="295"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="309"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="350"/>
+        <source>me</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="436"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/tego_ui/translation/ricochet_de.ts
+++ b/src/tego_ui/translation/ricochet_de.ts
@@ -21,29 +21,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="36"/>
-        <source>Ricochet Refresh web home page</source>
-        <extracomment>provides context for the URL for accessibility tech like screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="59"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="32"/>
         <source>The license of Ricochet Refresh and its dependencies</source>
-        <extracomment>summary of a block of text for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="60"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="33"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="65"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="37"/>
         <source>About</source>
         <translation type="unfinished">Über</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="39"/>
         <source>About page, contains license and version information</source>
         <extracomment>summary of the window&apos;s contents for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -105,37 +98,53 @@
 <context>
     <name>ContactActions</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="49"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <source>Could not successfully export conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="65"/>
         <source>Open Window</source>
         <extracomment>Context menu command to open the chat screen in a separate window</extracomment>
         <translation>Fenster öffnen</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="70"/>
         <source>Details...</source>
         <extracomment>Context menu command to open a window showing the selected contact&apos;s details</extracomment>
         <translation>Details...</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="56"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="75"/>
         <source>Rename</source>
         <extracomment>Context menu command to rename the selected contact</extracomment>
         <translation>Umbenennen</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="61"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="80"/>
         <source>Send File...</source>
         <extracomment>Context menu command to initiate a file transfer, opens a system file dialog</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="85"/>
+        <source>Export Conversation</source>
+        <extracomment>Context menu command to initiate a chat log export, opens a system file dialog to export to</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="91"/>
         <source>Remove</source>
         <extracomment>Context menu command to remove a contact from the contact list</extracomment>
         <translation>Entfernen</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="74"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="98"/>
         <source>Contact options</source>
         <extracomment>Description of the items in the context menu for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -151,30 +160,36 @@
     </message>
     <message>
         <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="45"/>
+        <source>This ID is invalid</source>
+        <extracomment>Error message showed when the id doesn&apos;t comply with spec https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
         <source>You can&apos;t add yourself as a contact</source>
         <extracomment>Error message showed when user attempts to add themselves as a contact in their contact list</extracomment>
         <translation>Du kannst dich nicht selbst als Kontakt hinzufügen</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="55"/>
         <source>Enter an ID starting with &lt;b&gt;ricochet:&lt;/b&gt;</source>
         <extracomment>Error message showed when the provided ricochet id is invalid</extracomment>
         <translation>Gebe eine ID an, beginnend mit &lt;b&gt;ricochet:&lt;b&gt;</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="88"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="97"/>
         <source>Copied to clipboard</source>
         <extracomment>Message displayed when text is copied to the user&apos;s clipboard</extracomment>
         <translation>In die Zwischenablage kopiert</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="103"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="112"/>
         <source>Copy</source>
         <extracomment>Text displayed on a button used to copy somethign to the user&apos;s clipboard</extracomment>
         <translation>Kopieren</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="119"/>
         <source>Copies the ricochet id to the clipboard</source>
         <extracomment>Text description of ricochet id copy button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -397,20 +412,19 @@
         <translation>Nutze ein einzelnes Fenster für Unterhaltungen</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Open links in default browser without prompting</source>
         <extracomment>Text description of an option to open URLs in default web browser when clicked</extracomment>
-        <translation>Öffne Links im Standardbrowser ohne Nachfrage</translation>
+        <translation type="vanished">Öffne Links im Standardbrowser ohne Nachfrage</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="44"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Play audio notifications</source>
         <extracomment>Text description of an option to play audio notifications when contacts log in, log out, and send messages</extracomment>
         <translation>Benachrichtigungston abspielen</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="61"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="77"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="62"/>
         <source>Volume</source>
         <extracomment>Label for a slider used to adjust audio notification volume
 ----------
@@ -418,8 +432,8 @@ Name of the slider used to adjust audio notification volume for accessibility te
         <translation>Lautstärke</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="91"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="129"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="114"/>
         <source>Language</source>
         <extracomment>Label for combobox where users can specify the UI language
 ----------
@@ -427,12 +441,12 @@ Name of the combobox used to select UI langauge for accessibility tech like scre
         <translation type="unfinished">Sprache</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="117"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="102"/>
         <source>Restart Ricochet to apply changes</source>
         <translation type="unfinished">Starte Ricochet neu, um Änderungung anzuwenden</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="131"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="116"/>
         <source>What language ricochet will use</source>
         <extracomment>Description of what the language combox is for for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -507,17 +521,17 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="157"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="151"/>
         <source>Version Seperator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="191"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="185"/>
         <source>Remove %1</source>
         <translation>Entferne %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="192"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="186"/>
         <source>Do you want to permanently remove %1?</source>
         <translation>Möchten Sie 1% permanent entfernen?</translation>
     </message>
@@ -549,79 +563,74 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>%1 ist offline</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="169"/>
         <source>File transfer file name</source>
         <extracomment>Description of the text displaying the filename of a file transfer, used by accessibility tech like screen readres</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="195"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="185"/>
         <source>File transfer progress</source>
         <extracomment>Description of progress bar displaying the file transfer progress, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="210"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="200"/>
         <source>File transfer status</source>
         <extracomment>Description of label displaying the current status of a file transfer, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="225"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="215"/>
         <source>Download</source>
         <extracomment>Label for file transfer &apos;Download&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="227"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="217"/>
         <source>Download file</source>
         <extracomment>Description of what the file transfer &apos;Download&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="244"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="234"/>
         <source>Cancel or reject</source>
         <extracomment>Label for file transfer &apos;Cancel&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="246"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="236"/>
         <source>Cancels or rejects a file transfer</source>
         <extracomment>Description of what the file transfer &apos;Cancel&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="310"/>
         <source>Copy ID</source>
         <extracomment>Text for context menu command to copy a ricochet contact id to clipboard</extracomment>
-        <translation>Kopiere ID</translation>
+        <translation type="vanished">Kopiere ID</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="281"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="312"/>
         <source>Copy Link</source>
         <extracomment>Text for context menu command to copy a url to the clipboard</extracomment>
-        <translation>Kopiere Link</translation>
+        <translation type="vanished">Kopiere Link</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="287"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="318"/>
         <source>Open with Browser</source>
         <extracomment>Text for context menu command to open a url in a web browser</extracomment>
-        <translation>Im Browser öffnen</translation>
+        <translation type="vanished">Im Browser öffnen</translation>
     </message>
     <message>
         <source>Add as Contact</source>
         <translation type="vanished">Als Kontakt hinzufügen</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="335"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="262"/>
         <source>Copy Message</source>
         <extracomment>Text for context menu command to copy an entire message to clipboard</extracomment>
         <translation>Nachricht kopieren</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="343"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="270"/>
         <source>Copy Selection</source>
         <extracomment>Text for context menu command to copy selected text to clipboard</extracomment>
         <translation>Auswahl kopieren</translation>
@@ -705,38 +714,28 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>OpenBrowserDialog</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="41"/>
         <source>&lt;b&gt;Warning!&lt;/b&gt; Opening links with your default browser will harm your security and anonymity.&lt;br&gt;&lt;br&gt;You can &lt;a href=&apos;.&apos;&gt;copy to the clipboard&lt;/a&gt; instead.</source>
         <extracomment>Label displayed when user clicks on a link</extracomment>
-        <translation>&lt;b&gt;Warnung!&lt;/b&gt; Links mit deinem Standardbrowser zu öffnen kann deine Sicherheit und Anonymität beeinträchtigen.&lt;br&gt; &lt;br&gt;Du kannst stattdessen &lt;a href=&apos;.&apos;&gt;in die Zwischenablage kopieren.&lt;/a&gt;</translation>
+        <translation type="vanished">&lt;b&gt;Warnung!&lt;/b&gt; Links mit deinem Standardbrowser zu öffnen kann deine Sicherheit und Anonymität beeinträchtigen.&lt;br&gt; &lt;br&gt;Du kannst stattdessen &lt;a href=&apos;.&apos;&gt;in die Zwischenablage kopieren.&lt;/a&gt;</translation>
     </message>
     <message>
         <source>Don&apos;t ask again for links from %1</source>
         <translation type="vanished">Nicht mehr fragen bei Links von %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="50"/>
-        <source>Warning</source>
-        <extracomment>Name of warning label used with accessibility tech such as screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="65"/>
         <source>Don&apos;t ask again for any links (not recommended!)</source>
         <extracomment>Checkbox option text for when user clicks on a link</extracomment>
-        <translation>Für keinen Link mehr nachfragen (nicht empfohlen!)</translation>
+        <translation type="vanished">Für keinen Link mehr nachfragen (nicht empfohlen!)</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="73"/>
         <source>Open Browser</source>
         <extracomment>Label on button to open link in a web browser</extracomment>
-        <translation>Browser öffnen</translation>
+        <translation type="vanished">Browser öffnen</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="84"/>
         <source>Cancel</source>
         <extracomment>Label on cancel button</extracomment>
-        <translation>Abbrechen</translation>
+        <translation type="vanished">Abbrechen</translation>
     </message>
 </context>
 <context>
@@ -878,144 +877,144 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>Benötigt dieser Rechner einen Proxy um sich mit dem Internet zu verbinden?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="69"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="70"/>
         <source>Proxy type:</source>
         <translation>Proxytyp:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="74"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="75"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="77"/>
         <source>None</source>
         <translation>Keiner</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="92"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="93"/>
         <source>If you need a proxy to access the internet, select one from this list.</source>
         <extracomment>Description used by accessibility tech, such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="97"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="98"/>
         <source>Address:</source>
         <extracomment>Label indicating the textbox to place a proxy IP or URL</extracomment>
         <translation>Adresse:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="111"/>
         <source>IP address or hostname</source>
         <extracomment>Placeholder text of text box expecting an IP or URL for proxy</extracomment>
         <translation>IP-Adresse oder Rechnername</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="115"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="116"/>
         <source>Enter the IP address or hostname of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the IP textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="119"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="120"/>
         <source>Port:</source>
         <extracomment>Label indicating the textbox to place a proxy port</extracomment>
         <translation>Port:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="130"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="131"/>
         <source>Port</source>
         <extracomment>Name of the port label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="132"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="133"/>
         <source>Enter the port of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the Port textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="138"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="139"/>
         <source>Username:</source>
         <extracomment>Label indicating the textbox to place the proxy username</extracomment>
         <translation>Benutzername:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="152"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="173"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="153"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="174"/>
         <source>Optional</source>
         <extracomment>Textbox placeholder text indicating the field is not required</extracomment>
         <translation>Fakultativ</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="156"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="157"/>
         <source>Username</source>
         <extracomment>Name of the username label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="158"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="159"/>
         <source>If required, enter the username for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Username textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="162"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="163"/>
         <source>Password:</source>
         <extracomment>Label indicating the textbox to place the proxy password</extracomment>
         <translation>Passwort:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="177"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="178"/>
         <source>Password</source>
         <extracomment>Name of the password label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="180"/>
         <source>If required, enter the password for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Password textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="190"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="191"/>
         <source>Does this computer&apos;s Internet connection go through a firewall that only allows connections to certain ports?</source>
         <extracomment>Description for the purpose of the Allowed Ports textbox</extracomment>
         <translation>Geht die Verbindung dieses Rechners durch eine Firewall, die nur Verbindungen zu manchen Ports erlaubt?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="211"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="212"/>
         <source>Allowed ports:</source>
         <extracomment>Label indicating the textbox to place the allowed ports</extracomment>
         <translation>Erlaubte Ports:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="220"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="221"/>
         <source>Example: 80,443</source>
         <extracomment>Textbox showing an example entry for the firewall allowed ports entry</extracomment>
         <translation>Beispiel: 80, 443</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="224"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="225"/>
         <source>Allowed ports</source>
         <extracomment>Name of the allowed ports label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="236"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="237"/>
         <source>If this computer&apos;s Internet connection is censored, you will need to obtain and use bridge relays.</source>
         <translation>Sollte die Internetverbindung dieses Rechners zensiert sein, werden Sie Brücken-Relays  finden und nutzen müssen.</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="251"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="262"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="252"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="263"/>
         <source>Enter one or more bridge relays (one per line):</source>
         <translation>Geben Sie ein oder mehrere Brücken-Relays an (eins pro Zeile):</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="273"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="274"/>
         <source>Back</source>
         <extracomment>Button label for going back to previous screen</extracomment>
         <translation>Zurück</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="284"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="285"/>
         <source>Connect</source>
         <extracomment>Button label for connecting to tor</extracomment>
         <translation>Verbinden</translation>
@@ -1192,51 +1191,65 @@ Name of the button for launching the preferences window for accessibility tech l
     </message>
     <message>
         <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="114"/>
+        <source>Accepted</source>
+        <translation type="unfinished">Akzeptiert</translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="115"/>
         <source>Rejected</source>
         <translation type="unfinished">Abgewiesen</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="120"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
         <source>Cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
         <source>Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
         <source>Unkown Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
         <source>Bad File Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
         <source>Network Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="126"/>
         <source>File System Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="127"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="128"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="220"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="223"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="395"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="285"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="289"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="295"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="309"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="350"/>
+        <source>me</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="436"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/tego_ui/translation/ricochet_en.ts
+++ b/src/tego_ui/translation/ricochet_en.ts
@@ -16,29 +16,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="36"/>
-        <source>Ricochet Refresh web home page</source>
-        <extracomment>provides context for the URL for accessibility tech like screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="59"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="32"/>
         <source>The license of Ricochet Refresh and its dependencies</source>
-        <extracomment>summary of a block of text for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="60"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="33"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="65"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="37"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="39"/>
         <source>About page, contains license and version information</source>
         <extracomment>summary of the window&apos;s contents for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -100,37 +93,53 @@
 <context>
     <name>ContactActions</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="49"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <source>Could not successfully export conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="65"/>
         <source>Open Window</source>
         <extracomment>Context menu command to open the chat screen in a separate window</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="70"/>
         <source>Details...</source>
         <extracomment>Context menu command to open a window showing the selected contact&apos;s details</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="56"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="75"/>
         <source>Rename</source>
         <extracomment>Context menu command to rename the selected contact</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="61"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="80"/>
         <source>Send File...</source>
         <extracomment>Context menu command to initiate a file transfer, opens a system file dialog</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="85"/>
+        <source>Export Conversation</source>
+        <extracomment>Context menu command to initiate a chat log export, opens a system file dialog to export to</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="91"/>
         <source>Remove</source>
         <extracomment>Context menu command to remove a contact from the contact list</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="74"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="98"/>
         <source>Contact options</source>
         <extracomment>Description of the items in the context menu for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -146,30 +155,36 @@
     </message>
     <message>
         <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="45"/>
+        <source>This ID is invalid</source>
+        <extracomment>Error message showed when the id doesn&apos;t comply with spec https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
         <source>You can&apos;t add yourself as a contact</source>
         <extracomment>Error message showed when user attempts to add themselves as a contact in their contact list</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="55"/>
         <source>Enter an ID starting with &lt;b&gt;ricochet:&lt;/b&gt;</source>
         <extracomment>Error message showed when the provided ricochet id is invalid</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="88"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="97"/>
         <source>Copied to clipboard</source>
         <extracomment>Message displayed when text is copied to the user&apos;s clipboard</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="103"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="112"/>
         <source>Copy</source>
         <extracomment>Text displayed on a button used to copy somethign to the user&apos;s clipboard</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="119"/>
         <source>Copies the ricochet id to the clipboard</source>
         <extracomment>Text description of ricochet id copy button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -348,19 +363,13 @@
     </message>
     <message>
         <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
-        <source>Open links in default browser without prompting</source>
-        <extracomment>Text description of an option to open URLs in default web browser when clicked</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="44"/>
         <source>Play audio notifications</source>
         <extracomment>Text description of an option to play audio notifications when contacts log in, log out, and send messages</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="61"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="77"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="62"/>
         <source>Volume</source>
         <extracomment>Label for a slider used to adjust audio notification volume
 ----------
@@ -368,8 +377,8 @@ Name of the slider used to adjust audio notification volume for accessibility te
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="91"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="129"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="114"/>
         <source>Language</source>
         <extracomment>Label for combobox where users can specify the UI language
 ----------
@@ -377,12 +386,12 @@ Name of the combobox used to select UI langauge for accessibility tech like scre
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="117"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="102"/>
         <source>Restart Ricochet to apply changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="131"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="116"/>
         <source>What language ricochet will use</source>
         <extracomment>Description of what the language combox is for for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -446,17 +455,17 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="157"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="151"/>
         <source>Version Seperator</source>
         <translation>dot</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="191"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="185"/>
         <source>Remove %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="192"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="186"/>
         <source>Do you want to permanently remove %1?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -488,75 +497,55 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="169"/>
         <source>File transfer file name</source>
         <extracomment>Description of the text displaying the filename of a file transfer, used by accessibility tech like screen readres</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="195"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="185"/>
         <source>File transfer progress</source>
         <extracomment>Description of progress bar displaying the file transfer progress, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="210"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="200"/>
         <source>File transfer status</source>
         <extracomment>Description of label displaying the current status of a file transfer, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="225"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="215"/>
         <source>Download</source>
         <extracomment>Label for file transfer &apos;Download&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="227"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="217"/>
         <source>Download file</source>
         <extracomment>Description of what the file transfer &apos;Download&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="244"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="234"/>
         <source>Cancel or reject</source>
         <extracomment>Label for file transfer &apos;Cancel&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="246"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="236"/>
         <source>Cancels or rejects a file transfer</source>
         <extracomment>Description of what the file transfer &apos;Cancel&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="310"/>
-        <source>Copy ID</source>
-        <extracomment>Text for context menu command to copy a ricochet contact id to clipboard</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="281"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="312"/>
-        <source>Copy Link</source>
-        <extracomment>Text for context menu command to copy a url to the clipboard</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="287"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="318"/>
-        <source>Open with Browser</source>
-        <extracomment>Text for context menu command to open a url in a web browser</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="335"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="262"/>
         <source>Copy Message</source>
         <extracomment>Text for context menu command to copy an entire message to clipboard</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="343"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="270"/>
         <source>Copy Selection</source>
         <extracomment>Text for context menu command to copy selected text to clipboard</extracomment>
         <translation type="unfinished"></translation>
@@ -634,39 +623,6 @@ Name of the button for launching the preferences window for accessibility tech l
         <location filename="../../libtego_ui/ui/qml/OfflineStateItem.qml" line="172"/>
         <source>Connecting…</source>
         <extracomment>Label displayed when in process of connecting, … is ellipsis</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>OpenBrowserDialog</name>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="41"/>
-        <source>&lt;b&gt;Warning!&lt;/b&gt; Opening links with your default browser will harm your security and anonymity.&lt;br&gt;&lt;br&gt;You can &lt;a href=&apos;.&apos;&gt;copy to the clipboard&lt;/a&gt; instead.</source>
-        <extracomment>Label displayed when user clicks on a link</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="50"/>
-        <source>Warning</source>
-        <extracomment>Name of warning label used with accessibility tech such as screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="65"/>
-        <source>Don&apos;t ask again for any links (not recommended!)</source>
-        <extracomment>Checkbox option text for when user clicks on a link</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="73"/>
-        <source>Open Browser</source>
-        <extracomment>Label on button to open link in a web browser</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="84"/>
-        <source>Cancel</source>
-        <extracomment>Label on cancel button</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -797,144 +753,144 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="69"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="70"/>
         <source>Proxy type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="74"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="75"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="77"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="92"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="93"/>
         <source>If you need a proxy to access the internet, select one from this list.</source>
         <extracomment>Description used by accessibility tech, such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="97"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="98"/>
         <source>Address:</source>
         <extracomment>Label indicating the textbox to place a proxy IP or URL</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="111"/>
         <source>IP address or hostname</source>
         <extracomment>Placeholder text of text box expecting an IP or URL for proxy</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="115"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="116"/>
         <source>Enter the IP address or hostname of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the IP textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="119"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="120"/>
         <source>Port:</source>
         <extracomment>Label indicating the textbox to place a proxy port</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="130"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="131"/>
         <source>Port</source>
         <extracomment>Name of the port label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="132"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="133"/>
         <source>Enter the port of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the Port textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="138"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="139"/>
         <source>Username:</source>
         <extracomment>Label indicating the textbox to place the proxy username</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="152"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="173"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="153"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="174"/>
         <source>Optional</source>
         <extracomment>Textbox placeholder text indicating the field is not required</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="156"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="157"/>
         <source>Username</source>
         <extracomment>Name of the username label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="158"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="159"/>
         <source>If required, enter the username for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Username textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="162"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="163"/>
         <source>Password:</source>
         <extracomment>Label indicating the textbox to place the proxy password</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="177"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="178"/>
         <source>Password</source>
         <extracomment>Name of the password label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="180"/>
         <source>If required, enter the password for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Password textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="190"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="191"/>
         <source>Does this computer&apos;s Internet connection go through a firewall that only allows connections to certain ports?</source>
         <extracomment>Description for the purpose of the Allowed Ports textbox</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="211"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="212"/>
         <source>Allowed ports:</source>
         <extracomment>Label indicating the textbox to place the allowed ports</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="220"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="221"/>
         <source>Example: 80,443</source>
         <extracomment>Textbox showing an example entry for the firewall allowed ports entry</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="224"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="225"/>
         <source>Allowed ports</source>
         <extracomment>Name of the allowed ports label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="236"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="237"/>
         <source>If this computer&apos;s Internet connection is censored, you will need to obtain and use bridge relays.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="251"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="262"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="252"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="263"/>
         <source>Enter one or more bridge relays (one per line):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="273"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="274"/>
         <source>Back</source>
         <extracomment>Button label for going back to previous screen</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="284"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="285"/>
         <source>Connect</source>
         <extracomment>Button label for connecting to tor</extracomment>
         <translation type="unfinished"></translation>
@@ -1107,51 +1063,65 @@ Name of the button for launching the preferences window for accessibility tech l
     </message>
     <message>
         <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="114"/>
+        <source>Accepted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="115"/>
         <source>Rejected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="120"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
         <source>Cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
         <source>Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
         <source>Unkown Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
         <source>Bad File Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
         <source>Network Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="126"/>
         <source>File System Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="127"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="128"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="220"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="223"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="395"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="285"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="289"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="295"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="309"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="350"/>
+        <source>me</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="436"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/tego_ui/translation/ricochet_es.ts
+++ b/src/tego_ui/translation/ricochet_es.ts
@@ -21,29 +21,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="36"/>
-        <source>Ricochet Refresh web home page</source>
-        <extracomment>provides context for the URL for accessibility tech like screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="59"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="32"/>
         <source>The license of Ricochet Refresh and its dependencies</source>
-        <extracomment>summary of a block of text for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="60"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="33"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="65"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="37"/>
         <source>About</source>
         <translation type="unfinished">Acerca de</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="39"/>
         <source>About page, contains license and version information</source>
         <extracomment>summary of the window&apos;s contents for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -105,37 +98,53 @@
 <context>
     <name>ContactActions</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="49"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <source>Could not successfully export conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="65"/>
         <source>Open Window</source>
         <extracomment>Context menu command to open the chat screen in a separate window</extracomment>
         <translation>Abrir Ventana</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="70"/>
         <source>Details...</source>
         <extracomment>Context menu command to open a window showing the selected contact&apos;s details</extracomment>
         <translation>Detalles...</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="56"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="75"/>
         <source>Rename</source>
         <extracomment>Context menu command to rename the selected contact</extracomment>
         <translation>Renombrar</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="61"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="80"/>
         <source>Send File...</source>
         <extracomment>Context menu command to initiate a file transfer, opens a system file dialog</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="85"/>
+        <source>Export Conversation</source>
+        <extracomment>Context menu command to initiate a chat log export, opens a system file dialog to export to</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="91"/>
         <source>Remove</source>
         <extracomment>Context menu command to remove a contact from the contact list</extracomment>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="74"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="98"/>
         <source>Contact options</source>
         <extracomment>Description of the items in the context menu for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -151,30 +160,36 @@
     </message>
     <message>
         <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="45"/>
+        <source>This ID is invalid</source>
+        <extracomment>Error message showed when the id doesn&apos;t comply with spec https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
         <source>You can&apos;t add yourself as a contact</source>
         <extracomment>Error message showed when user attempts to add themselves as a contact in their contact list</extracomment>
         <translation>No puede añadirse a usted mismo como un contacto</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="55"/>
         <source>Enter an ID starting with &lt;b&gt;ricochet:&lt;/b&gt;</source>
         <extracomment>Error message showed when the provided ricochet id is invalid</extracomment>
         <translation>Introduzca un ID comience con &lt;b&gt;ricochet:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="88"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="97"/>
         <source>Copied to clipboard</source>
         <extracomment>Message displayed when text is copied to the user&apos;s clipboard</extracomment>
         <translation>Copiado al portapapeles</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="103"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="112"/>
         <source>Copy</source>
         <extracomment>Text displayed on a button used to copy somethign to the user&apos;s clipboard</extracomment>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="119"/>
         <source>Copies the ricochet id to the clipboard</source>
         <extracomment>Text description of ricochet id copy button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -397,20 +412,19 @@
         <translation>Usar una única ventana para conversaciones</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Open links in default browser without prompting</source>
         <extracomment>Text description of an option to open URLs in default web browser when clicked</extracomment>
-        <translation>Abrir enlaces en el navegador predeterminado sin pedir confirmación</translation>
+        <translation type="vanished">Abrir enlaces en el navegador predeterminado sin pedir confirmación</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="44"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Play audio notifications</source>
         <extracomment>Text description of an option to play audio notifications when contacts log in, log out, and send messages</extracomment>
         <translation>Reproducir notificaciones de audio</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="61"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="77"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="62"/>
         <source>Volume</source>
         <extracomment>Label for a slider used to adjust audio notification volume
 ----------
@@ -418,8 +432,8 @@ Name of the slider used to adjust audio notification volume for accessibility te
         <translation>Volumen</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="91"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="129"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="114"/>
         <source>Language</source>
         <extracomment>Label for combobox where users can specify the UI language
 ----------
@@ -427,12 +441,12 @@ Name of the combobox used to select UI langauge for accessibility tech like scre
         <translation type="unfinished">Idioma</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="117"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="102"/>
         <source>Restart Ricochet to apply changes</source>
         <translation type="unfinished">Reiniciar Ricochet para aplicar los cambios</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="131"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="116"/>
         <source>What language ricochet will use</source>
         <extracomment>Description of what the language combox is for for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -507,17 +521,17 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="157"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="151"/>
         <source>Version Seperator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="191"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="185"/>
         <source>Remove %1</source>
         <translation>Eliminar %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="192"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="186"/>
         <source>Do you want to permanently remove %1?</source>
         <translation>¿Quiere eliminar permanentemente a %1?</translation>
     </message>
@@ -549,79 +563,74 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>%1 está fuera de línea</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="169"/>
         <source>File transfer file name</source>
         <extracomment>Description of the text displaying the filename of a file transfer, used by accessibility tech like screen readres</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="195"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="185"/>
         <source>File transfer progress</source>
         <extracomment>Description of progress bar displaying the file transfer progress, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="210"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="200"/>
         <source>File transfer status</source>
         <extracomment>Description of label displaying the current status of a file transfer, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="225"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="215"/>
         <source>Download</source>
         <extracomment>Label for file transfer &apos;Download&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="227"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="217"/>
         <source>Download file</source>
         <extracomment>Description of what the file transfer &apos;Download&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="244"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="234"/>
         <source>Cancel or reject</source>
         <extracomment>Label for file transfer &apos;Cancel&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="246"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="236"/>
         <source>Cancels or rejects a file transfer</source>
         <extracomment>Description of what the file transfer &apos;Cancel&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="310"/>
         <source>Copy ID</source>
         <extracomment>Text for context menu command to copy a ricochet contact id to clipboard</extracomment>
-        <translation>Copiar ID (identificador)</translation>
+        <translation type="vanished">Copiar ID (identificador)</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="281"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="312"/>
         <source>Copy Link</source>
         <extracomment>Text for context menu command to copy a url to the clipboard</extracomment>
-        <translation>Copiar Enlace</translation>
+        <translation type="vanished">Copiar Enlace</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="287"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="318"/>
         <source>Open with Browser</source>
         <extracomment>Text for context menu command to open a url in a web browser</extracomment>
-        <translation>Abrir con el Navegador</translation>
+        <translation type="vanished">Abrir con el Navegador</translation>
     </message>
     <message>
         <source>Add as Contact</source>
         <translation type="vanished">Añadir como Contacto</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="335"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="262"/>
         <source>Copy Message</source>
         <extracomment>Text for context menu command to copy an entire message to clipboard</extracomment>
         <translation>Copiar mensaje</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="343"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="270"/>
         <source>Copy Selection</source>
         <extracomment>Text for context menu command to copy selected text to clipboard</extracomment>
         <translation>Copiar selección</translation>
@@ -705,38 +714,28 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>OpenBrowserDialog</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="41"/>
         <source>&lt;b&gt;Warning!&lt;/b&gt; Opening links with your default browser will harm your security and anonymity.&lt;br&gt;&lt;br&gt;You can &lt;a href=&apos;.&apos;&gt;copy to the clipboard&lt;/a&gt; instead.</source>
         <extracomment>Label displayed when user clicks on a link</extracomment>
-        <translation>&lt;b&gt;¡Advertencia!&lt;/b&gt; Abrir enlaces con su navegador predeterminado perjudicará su seguridad y anonimato. &lt;br&gt;&lt;br&gt;En su lugar puede &lt;a href=&apos;.&apos;&gt;copiarlos al portapapeles&lt;/a&gt;.</translation>
+        <translation type="vanished">&lt;b&gt;¡Advertencia!&lt;/b&gt; Abrir enlaces con su navegador predeterminado perjudicará su seguridad y anonimato. &lt;br&gt;&lt;br&gt;En su lugar puede &lt;a href=&apos;.&apos;&gt;copiarlos al portapapeles&lt;/a&gt;.</translation>
     </message>
     <message>
         <source>Don&apos;t ask again for links from %1</source>
         <translation type="vanished">No volver a preguntar por enlaces desde %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="50"/>
-        <source>Warning</source>
-        <extracomment>Name of warning label used with accessibility tech such as screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="65"/>
         <source>Don&apos;t ask again for any links (not recommended!)</source>
         <extracomment>Checkbox option text for when user clicks on a link</extracomment>
-        <translation>No volver a preguntar por ningún enlace (¡no recomendado!)</translation>
+        <translation type="vanished">No volver a preguntar por ningún enlace (¡no recomendado!)</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="73"/>
         <source>Open Browser</source>
         <extracomment>Label on button to open link in a web browser</extracomment>
-        <translation>Abrir Navegador</translation>
+        <translation type="vanished">Abrir Navegador</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="84"/>
         <source>Cancel</source>
         <extracomment>Label on cancel button</extracomment>
-        <translation>Cancelar</translation>
+        <translation type="vanished">Cancelar</translation>
     </message>
 </context>
 <context>
@@ -878,144 +877,144 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>¿Este equipo necesita un proxy para acceder a Internet?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="69"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="70"/>
         <source>Proxy type:</source>
         <translation>Tipo de proxy:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="74"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="75"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="77"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="92"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="93"/>
         <source>If you need a proxy to access the internet, select one from this list.</source>
         <extracomment>Description used by accessibility tech, such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="97"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="98"/>
         <source>Address:</source>
         <extracomment>Label indicating the textbox to place a proxy IP or URL</extracomment>
         <translation>Dirección:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="111"/>
         <source>IP address or hostname</source>
         <extracomment>Placeholder text of text box expecting an IP or URL for proxy</extracomment>
         <translation>Dirección IP o nombre del equipo</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="115"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="116"/>
         <source>Enter the IP address or hostname of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the IP textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="119"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="120"/>
         <source>Port:</source>
         <extracomment>Label indicating the textbox to place a proxy port</extracomment>
         <translation>Puerto:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="130"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="131"/>
         <source>Port</source>
         <extracomment>Name of the port label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="132"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="133"/>
         <source>Enter the port of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the Port textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="138"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="139"/>
         <source>Username:</source>
         <extracomment>Label indicating the textbox to place the proxy username</extracomment>
         <translation>Nombre de usuario:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="152"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="173"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="153"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="174"/>
         <source>Optional</source>
         <extracomment>Textbox placeholder text indicating the field is not required</extracomment>
         <translation>Opcional</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="156"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="157"/>
         <source>Username</source>
         <extracomment>Name of the username label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="158"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="159"/>
         <source>If required, enter the username for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Username textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="162"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="163"/>
         <source>Password:</source>
         <extracomment>Label indicating the textbox to place the proxy password</extracomment>
         <translation>Contraseña:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="177"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="178"/>
         <source>Password</source>
         <extracomment>Name of the password label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="180"/>
         <source>If required, enter the password for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Password textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="190"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="191"/>
         <source>Does this computer&apos;s Internet connection go through a firewall that only allows connections to certain ports?</source>
         <extracomment>Description for the purpose of the Allowed Ports textbox</extracomment>
         <translation>¿La conexión a Internet de este equipo va a través de un cortafuegos (firewall) que sólo permite conexiones a ciertos puertos?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="211"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="212"/>
         <source>Allowed ports:</source>
         <extracomment>Label indicating the textbox to place the allowed ports</extracomment>
         <translation>Puertos permitidos:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="220"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="221"/>
         <source>Example: 80,443</source>
         <extracomment>Textbox showing an example entry for the firewall allowed ports entry</extracomment>
         <translation>Ejemplo: 80,443</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="224"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="225"/>
         <source>Allowed ports</source>
         <extracomment>Name of the allowed ports label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="236"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="237"/>
         <source>If this computer&apos;s Internet connection is censored, you will need to obtain and use bridge relays.</source>
         <translation>Si la conexión a Internet de este equipo está bajo censura, necesitará obtener y usar repetidores puente (bridge relays).</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="251"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="262"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="252"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="263"/>
         <source>Enter one or more bridge relays (one per line):</source>
         <translation>Introduzca uno o más repetidores puente (uno por línea):</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="273"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="274"/>
         <source>Back</source>
         <extracomment>Button label for going back to previous screen</extracomment>
         <translation>Atrás</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="284"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="285"/>
         <source>Connect</source>
         <extracomment>Button label for connecting to tor</extracomment>
         <translation>Conectar</translation>
@@ -1192,51 +1191,65 @@ Name of the button for launching the preferences window for accessibility tech l
     </message>
     <message>
         <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="114"/>
+        <source>Accepted</source>
+        <translation type="unfinished">Aceptado</translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="115"/>
         <source>Rejected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="120"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
         <source>Cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
         <source>Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
         <source>Unkown Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
         <source>Bad File Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
         <source>Network Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="126"/>
         <source>File System Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="127"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="128"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="220"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="223"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="395"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="285"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="289"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="295"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="309"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="350"/>
+        <source>me</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="436"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/tego_ui/translation/ricochet_et_EE.ts
+++ b/src/tego_ui/translation/ricochet_et_EE.ts
@@ -21,29 +21,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="36"/>
-        <source>Ricochet Refresh web home page</source>
-        <extracomment>provides context for the URL for accessibility tech like screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="59"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="32"/>
         <source>The license of Ricochet Refresh and its dependencies</source>
-        <extracomment>summary of a block of text for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="60"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="33"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="65"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="37"/>
         <source>About</source>
         <translation type="unfinished">Lähemalt</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="39"/>
         <source>About page, contains license and version information</source>
         <extracomment>summary of the window&apos;s contents for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -105,37 +98,53 @@
 <context>
     <name>ContactActions</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="49"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <source>Could not successfully export conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="65"/>
         <source>Open Window</source>
         <extracomment>Context menu command to open the chat screen in a separate window</extracomment>
         <translation>Ava aken</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="70"/>
         <source>Details...</source>
         <extracomment>Context menu command to open a window showing the selected contact&apos;s details</extracomment>
         <translation>Detailid...</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="56"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="75"/>
         <source>Rename</source>
         <extracomment>Context menu command to rename the selected contact</extracomment>
         <translation>Nimeta ümber</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="61"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="80"/>
         <source>Send File...</source>
         <extracomment>Context menu command to initiate a file transfer, opens a system file dialog</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="85"/>
+        <source>Export Conversation</source>
+        <extracomment>Context menu command to initiate a chat log export, opens a system file dialog to export to</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="91"/>
         <source>Remove</source>
         <extracomment>Context menu command to remove a contact from the contact list</extracomment>
         <translation>Eemalda</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="74"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="98"/>
         <source>Contact options</source>
         <extracomment>Description of the items in the context menu for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -151,30 +160,36 @@
     </message>
     <message>
         <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="45"/>
+        <source>This ID is invalid</source>
+        <extracomment>Error message showed when the id doesn&apos;t comply with spec https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
         <source>You can&apos;t add yourself as a contact</source>
         <extracomment>Error message showed when user attempts to add themselves as a contact in their contact list</extracomment>
         <translation>Sa ei saa lisada ennast kontaktiks</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="55"/>
         <source>Enter an ID starting with &lt;b&gt;ricochet:&lt;/b&gt;</source>
         <extracomment>Error message showed when the provided ricochet id is invalid</extracomment>
         <translation>Sisesta ID koos &lt;b&gt;ricochet:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="88"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="97"/>
         <source>Copied to clipboard</source>
         <extracomment>Message displayed when text is copied to the user&apos;s clipboard</extracomment>
         <translation>Kopeeri lõikeväljale</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="103"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="112"/>
         <source>Copy</source>
         <extracomment>Text displayed on a button used to copy somethign to the user&apos;s clipboard</extracomment>
         <translation>Kopeeri</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="119"/>
         <source>Copies the ricochet id to the clipboard</source>
         <extracomment>Text description of ricochet id copy button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -397,20 +412,19 @@
         <translation>Kasuta eraldi akent suhtlemiseks</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Open links in default browser without prompting</source>
         <extracomment>Text description of an option to open URLs in default web browser when clicked</extracomment>
-        <translation>Ava lingid vaikimsi brauseriga ilma märguandeta</translation>
+        <translation type="vanished">Ava lingid vaikimsi brauseriga ilma märguandeta</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="44"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Play audio notifications</source>
         <extracomment>Text description of an option to play audio notifications when contacts log in, log out, and send messages</extracomment>
         <translation>Mängi heli märguandeid</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="61"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="77"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="62"/>
         <source>Volume</source>
         <extracomment>Label for a slider used to adjust audio notification volume
 ----------
@@ -418,8 +432,8 @@ Name of the slider used to adjust audio notification volume for accessibility te
         <translation>Heli valjus</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="91"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="129"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="114"/>
         <source>Language</source>
         <extracomment>Label for combobox where users can specify the UI language
 ----------
@@ -427,12 +441,12 @@ Name of the combobox used to select UI langauge for accessibility tech like scre
         <translation type="unfinished">Keel</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="117"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="102"/>
         <source>Restart Ricochet to apply changes</source>
         <translation type="unfinished">Taaskäivita Ricochet muudatuste jaoks </translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="131"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="116"/>
         <source>What language ricochet will use</source>
         <extracomment>Description of what the language combox is for for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -507,17 +521,17 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="157"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="151"/>
         <source>Version Seperator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="191"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="185"/>
         <source>Remove %1</source>
         <translation>Eemalda %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="192"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="186"/>
         <source>Do you want to permanently remove %1?</source>
         <translation>Kas sa tahad tingimata eemaldada: %1?</translation>
     </message>
@@ -549,79 +563,74 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>%1 on võrgust väljas</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="169"/>
         <source>File transfer file name</source>
         <extracomment>Description of the text displaying the filename of a file transfer, used by accessibility tech like screen readres</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="195"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="185"/>
         <source>File transfer progress</source>
         <extracomment>Description of progress bar displaying the file transfer progress, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="210"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="200"/>
         <source>File transfer status</source>
         <extracomment>Description of label displaying the current status of a file transfer, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="225"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="215"/>
         <source>Download</source>
         <extracomment>Label for file transfer &apos;Download&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="227"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="217"/>
         <source>Download file</source>
         <extracomment>Description of what the file transfer &apos;Download&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="244"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="234"/>
         <source>Cancel or reject</source>
         <extracomment>Label for file transfer &apos;Cancel&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="246"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="236"/>
         <source>Cancels or rejects a file transfer</source>
         <extracomment>Description of what the file transfer &apos;Cancel&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="310"/>
         <source>Copy ID</source>
         <extracomment>Text for context menu command to copy a ricochet contact id to clipboard</extracomment>
-        <translation>Kopeeri ID</translation>
+        <translation type="vanished">Kopeeri ID</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="281"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="312"/>
         <source>Copy Link</source>
         <extracomment>Text for context menu command to copy a url to the clipboard</extracomment>
-        <translation>Kopeeri link</translation>
+        <translation type="vanished">Kopeeri link</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="287"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="318"/>
         <source>Open with Browser</source>
         <extracomment>Text for context menu command to open a url in a web browser</extracomment>
-        <translation>Ava koos veebilehitsejaga</translation>
+        <translation type="vanished">Ava koos veebilehitsejaga</translation>
     </message>
     <message>
         <source>Add as Contact</source>
         <translation type="vanished">Lisa kontaktina</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="335"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="262"/>
         <source>Copy Message</source>
         <extracomment>Text for context menu command to copy an entire message to clipboard</extracomment>
         <translation>Kopeeri sõnum</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="343"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="270"/>
         <source>Copy Selection</source>
         <extracomment>Text for context menu command to copy selected text to clipboard</extracomment>
         <translation>Kopeeri valik</translation>
@@ -705,38 +714,28 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>OpenBrowserDialog</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="41"/>
         <source>&lt;b&gt;Warning!&lt;/b&gt; Opening links with your default browser will harm your security and anonymity.&lt;br&gt;&lt;br&gt;You can &lt;a href=&apos;.&apos;&gt;copy to the clipboard&lt;/a&gt; instead.</source>
         <extracomment>Label displayed when user clicks on a link</extracomment>
-        <translation>&lt;b&gt;Hoiatus!&lt;/b&gt; Lingi avamine sinu veebilehitsejaga võib vähendada sinu turvalisust ja anonüümsust.&lt;br&gt;&lt;br&gt;Sa võid hoopis&lt;a href=&apos;.&apos;&gt;kopeerida lõikeväljale&lt;/a&gt; .</translation>
+        <translation type="vanished">&lt;b&gt;Hoiatus!&lt;/b&gt; Lingi avamine sinu veebilehitsejaga võib vähendada sinu turvalisust ja anonüümsust.&lt;br&gt;&lt;br&gt;Sa võid hoopis&lt;a href=&apos;.&apos;&gt;kopeerida lõikeväljale&lt;/a&gt; .</translation>
     </message>
     <message>
         <source>Don&apos;t ask again for links from %1</source>
         <translation type="vanished">Ära küsi enam linke %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="50"/>
-        <source>Warning</source>
-        <extracomment>Name of warning label used with accessibility tech such as screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="65"/>
         <source>Don&apos;t ask again for any links (not recommended!)</source>
         <extracomment>Checkbox option text for when user clicks on a link</extracomment>
-        <translation>Ära küsi rohkem mitte ühegi linkide kohta (ei ole soovitatud!)</translation>
+        <translation type="vanished">Ära küsi rohkem mitte ühegi linkide kohta (ei ole soovitatud!)</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="73"/>
         <source>Open Browser</source>
         <extracomment>Label on button to open link in a web browser</extracomment>
-        <translation>Ava Brauser</translation>
+        <translation type="vanished">Ava Brauser</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="84"/>
         <source>Cancel</source>
         <extracomment>Label on cancel button</extracomment>
-        <translation>Tühista</translation>
+        <translation type="vanished">Tühista</translation>
     </message>
 </context>
 <context>
@@ -878,144 +877,144 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>Kas see arvuti vajab interneti ühendamiseks proksit?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="69"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="70"/>
         <source>Proxy type:</source>
         <translation>Proksi tüüp:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="74"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="75"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="77"/>
         <source>None</source>
         <translation>Ei ole</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="92"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="93"/>
         <source>If you need a proxy to access the internet, select one from this list.</source>
         <extracomment>Description used by accessibility tech, such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="97"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="98"/>
         <source>Address:</source>
         <extracomment>Label indicating the textbox to place a proxy IP or URL</extracomment>
         <translation>Aadress:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="111"/>
         <source>IP address or hostname</source>
         <extracomment>Placeholder text of text box expecting an IP or URL for proxy</extracomment>
         <translation>IP aadress või hostinimi</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="115"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="116"/>
         <source>Enter the IP address or hostname of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the IP textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="119"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="120"/>
         <source>Port:</source>
         <extracomment>Label indicating the textbox to place a proxy port</extracomment>
         <translation>Port:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="130"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="131"/>
         <source>Port</source>
         <extracomment>Name of the port label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="132"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="133"/>
         <source>Enter the port of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the Port textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="138"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="139"/>
         <source>Username:</source>
         <extracomment>Label indicating the textbox to place the proxy username</extracomment>
         <translation>Kasutajanimi:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="152"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="173"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="153"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="174"/>
         <source>Optional</source>
         <extracomment>Textbox placeholder text indicating the field is not required</extracomment>
         <translation>Valikuline</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="156"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="157"/>
         <source>Username</source>
         <extracomment>Name of the username label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="158"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="159"/>
         <source>If required, enter the username for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Username textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="162"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="163"/>
         <source>Password:</source>
         <extracomment>Label indicating the textbox to place the proxy password</extracomment>
         <translation>Parool:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="177"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="178"/>
         <source>Password</source>
         <extracomment>Name of the password label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="180"/>
         <source>If required, enter the password for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Password textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="190"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="191"/>
         <source>Does this computer&apos;s Internet connection go through a firewall that only allows connections to certain ports?</source>
         <extracomment>Description for the purpose of the Allowed Ports textbox</extracomment>
         <translation>Kas see arvuti vajab interneti ühenduseks läbi tulemüüri ainult teatuid porte?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="211"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="212"/>
         <source>Allowed ports:</source>
         <extracomment>Label indicating the textbox to place the allowed ports</extracomment>
         <translation>Lubatud pordid:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="220"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="221"/>
         <source>Example: 80,443</source>
         <extracomment>Textbox showing an example entry for the firewall allowed ports entry</extracomment>
         <translation>Näide: 80.443</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="224"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="225"/>
         <source>Allowed ports</source>
         <extracomment>Name of the allowed ports label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="236"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="237"/>
         <source>If this computer&apos;s Internet connection is censored, you will need to obtain and use bridge relays.</source>
         <translation>Kui selle arvuti internetiühendus on senseeritud, siis vajad ja pead saama kasutada sildühendusi.</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="251"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="262"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="252"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="263"/>
         <source>Enter one or more bridge relays (one per line):</source>
         <translation>Sisesta üks või rohkem sildühendusi (üks rea kohta):</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="273"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="274"/>
         <source>Back</source>
         <extracomment>Button label for going back to previous screen</extracomment>
         <translation>Tagasi</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="284"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="285"/>
         <source>Connect</source>
         <extracomment>Button label for connecting to tor</extracomment>
         <translation>Ühenda</translation>
@@ -1192,51 +1191,65 @@ Name of the button for launching the preferences window for accessibility tech l
     </message>
     <message>
         <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="114"/>
+        <source>Accepted</source>
+        <translation type="unfinished">Aksepteeritud</translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="115"/>
         <source>Rejected</source>
         <translation type="unfinished">Tagasi lükatud</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="120"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
         <source>Cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
         <source>Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
         <source>Unkown Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
         <source>Bad File Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
         <source>Network Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="126"/>
         <source>File System Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="127"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="128"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="220"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="223"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="395"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="285"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="289"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="295"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="309"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="350"/>
+        <source>me</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="436"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/tego_ui/translation/ricochet_fi.ts
+++ b/src/tego_ui/translation/ricochet_fi.ts
@@ -21,29 +21,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="36"/>
-        <source>Ricochet Refresh web home page</source>
-        <extracomment>provides context for the URL for accessibility tech like screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="59"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="32"/>
         <source>The license of Ricochet Refresh and its dependencies</source>
-        <extracomment>summary of a block of text for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="60"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="33"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="65"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="37"/>
         <source>About</source>
         <translation type="unfinished">Tietoa</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="39"/>
         <source>About page, contains license and version information</source>
         <extracomment>summary of the window&apos;s contents for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -105,37 +98,53 @@
 <context>
     <name>ContactActions</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="49"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <source>Could not successfully export conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="65"/>
         <source>Open Window</source>
         <extracomment>Context menu command to open the chat screen in a separate window</extracomment>
         <translation>Avaa ikkuna</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="70"/>
         <source>Details...</source>
         <extracomment>Context menu command to open a window showing the selected contact&apos;s details</extracomment>
         <translation>Tiedot...</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="56"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="75"/>
         <source>Rename</source>
         <extracomment>Context menu command to rename the selected contact</extracomment>
         <translation>Nimeä uudelleen</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="61"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="80"/>
         <source>Send File...</source>
         <extracomment>Context menu command to initiate a file transfer, opens a system file dialog</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="85"/>
+        <source>Export Conversation</source>
+        <extracomment>Context menu command to initiate a chat log export, opens a system file dialog to export to</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="91"/>
         <source>Remove</source>
         <extracomment>Context menu command to remove a contact from the contact list</extracomment>
         <translation>Poista</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="74"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="98"/>
         <source>Contact options</source>
         <extracomment>Description of the items in the context menu for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -151,30 +160,36 @@
     </message>
     <message>
         <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="45"/>
+        <source>This ID is invalid</source>
+        <extracomment>Error message showed when the id doesn&apos;t comply with spec https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
         <source>You can&apos;t add yourself as a contact</source>
         <extracomment>Error message showed when user attempts to add themselves as a contact in their contact list</extracomment>
         <translation>Et voi lisätä itseäsi kontaktiksi</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="55"/>
         <source>Enter an ID starting with &lt;b&gt;ricochet:&lt;/b&gt;</source>
         <extracomment>Error message showed when the provided ricochet id is invalid</extracomment>
         <translation>Anna ID joka alkaa &lt;b&gt;ricochet:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="88"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="97"/>
         <source>Copied to clipboard</source>
         <extracomment>Message displayed when text is copied to the user&apos;s clipboard</extracomment>
         <translation>Kopioitu leikepöydälle</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="103"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="112"/>
         <source>Copy</source>
         <extracomment>Text displayed on a button used to copy somethign to the user&apos;s clipboard</extracomment>
         <translation>Kopioi</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="119"/>
         <source>Copies the ricochet id to the clipboard</source>
         <extracomment>Text description of ricochet id copy button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -397,20 +412,19 @@
         <translation>Käytä yhtä ikkunaa keskusteluille</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Open links in default browser without prompting</source>
         <extracomment>Text description of an option to open URLs in default web browser when clicked</extracomment>
-        <translation>Avaa linkit oletusselaimella ilman vahvistusta</translation>
+        <translation type="vanished">Avaa linkit oletusselaimella ilman vahvistusta</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="44"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Play audio notifications</source>
         <extracomment>Text description of an option to play audio notifications when contacts log in, log out, and send messages</extracomment>
         <translation>Soita huomioäänimerkkejä</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="61"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="77"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="62"/>
         <source>Volume</source>
         <extracomment>Label for a slider used to adjust audio notification volume
 ----------
@@ -418,8 +432,8 @@ Name of the slider used to adjust audio notification volume for accessibility te
         <translation>Äänenvoimakkuus</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="91"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="129"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="114"/>
         <source>Language</source>
         <extracomment>Label for combobox where users can specify the UI language
 ----------
@@ -427,12 +441,12 @@ Name of the combobox used to select UI langauge for accessibility tech like scre
         <translation type="unfinished">Kieli</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="117"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="102"/>
         <source>Restart Ricochet to apply changes</source>
         <translation type="unfinished">Käynnistä Ricochet uudelleen ottaaksesi tehdyt muutokset käyttöön</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="131"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="116"/>
         <source>What language ricochet will use</source>
         <extracomment>Description of what the language combox is for for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -507,17 +521,17 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="157"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="151"/>
         <source>Version Seperator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="191"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="185"/>
         <source>Remove %1</source>
         <translation>Poista %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="192"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="186"/>
         <source>Do you want to permanently remove %1?</source>
         <translation>Haluatko poistaa tämän pysyvästi: %1?</translation>
     </message>
@@ -549,79 +563,74 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>%1 ei ole linjoilla</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="169"/>
         <source>File transfer file name</source>
         <extracomment>Description of the text displaying the filename of a file transfer, used by accessibility tech like screen readres</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="195"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="185"/>
         <source>File transfer progress</source>
         <extracomment>Description of progress bar displaying the file transfer progress, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="210"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="200"/>
         <source>File transfer status</source>
         <extracomment>Description of label displaying the current status of a file transfer, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="225"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="215"/>
         <source>Download</source>
         <extracomment>Label for file transfer &apos;Download&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="227"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="217"/>
         <source>Download file</source>
         <extracomment>Description of what the file transfer &apos;Download&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="244"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="234"/>
         <source>Cancel or reject</source>
         <extracomment>Label for file transfer &apos;Cancel&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="246"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="236"/>
         <source>Cancels or rejects a file transfer</source>
         <extracomment>Description of what the file transfer &apos;Cancel&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="310"/>
         <source>Copy ID</source>
         <extracomment>Text for context menu command to copy a ricochet contact id to clipboard</extracomment>
-        <translation>Kopioi ID</translation>
+        <translation type="vanished">Kopioi ID</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="281"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="312"/>
         <source>Copy Link</source>
         <extracomment>Text for context menu command to copy a url to the clipboard</extracomment>
-        <translation>Kopioi linkki</translation>
+        <translation type="vanished">Kopioi linkki</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="287"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="318"/>
         <source>Open with Browser</source>
         <extracomment>Text for context menu command to open a url in a web browser</extracomment>
-        <translation>Avaa selaimessa</translation>
+        <translation type="vanished">Avaa selaimessa</translation>
     </message>
     <message>
         <source>Add as Contact</source>
         <translation type="vanished">Lisää kontaktiksi</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="335"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="262"/>
         <source>Copy Message</source>
         <extracomment>Text for context menu command to copy an entire message to clipboard</extracomment>
         <translation>Kopioi viesti</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="343"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="270"/>
         <source>Copy Selection</source>
         <extracomment>Text for context menu command to copy selected text to clipboard</extracomment>
         <translation>Kopioi valinta</translation>
@@ -705,38 +714,28 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>OpenBrowserDialog</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="41"/>
         <source>&lt;b&gt;Warning!&lt;/b&gt; Opening links with your default browser will harm your security and anonymity.&lt;br&gt;&lt;br&gt;You can &lt;a href=&apos;.&apos;&gt;copy to the clipboard&lt;/a&gt; instead.</source>
         <extracomment>Label displayed when user clicks on a link</extracomment>
-        <translation>&lt;b&gt;Varoitus!&lt;/b&gt; Linkkien avaaminen oletusselaimessasi voi vaarantaa tietoturvaasi ja yksityisyyttäsi.&lt;br&gt;&lt;br&gt;Voit &lt;a href=&apos;.&apos;&gt;kopioida linkin leikepöydälle&lt;/a&gt; tämän sijaan.</translation>
+        <translation type="vanished">&lt;b&gt;Varoitus!&lt;/b&gt; Linkkien avaaminen oletusselaimessasi voi vaarantaa tietoturvaasi ja yksityisyyttäsi.&lt;br&gt;&lt;br&gt;Voit &lt;a href=&apos;.&apos;&gt;kopioida linkin leikepöydälle&lt;/a&gt; tämän sijaan.</translation>
     </message>
     <message>
         <source>Don&apos;t ask again for links from %1</source>
         <translation type="vanished">Älä kysy uudestaan linkeistä joiden lähteenä on %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="50"/>
-        <source>Warning</source>
-        <extracomment>Name of warning label used with accessibility tech such as screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="65"/>
         <source>Don&apos;t ask again for any links (not recommended!)</source>
         <extracomment>Checkbox option text for when user clicks on a link</extracomment>
-        <translation>Älä kysy uudestaan mistään linkeistä (Ei suositella!)</translation>
+        <translation type="vanished">Älä kysy uudestaan mistään linkeistä (Ei suositella!)</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="73"/>
         <source>Open Browser</source>
         <extracomment>Label on button to open link in a web browser</extracomment>
-        <translation>Avaa selain</translation>
+        <translation type="vanished">Avaa selain</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="84"/>
         <source>Cancel</source>
         <extracomment>Label on cancel button</extracomment>
-        <translation>Peruuta</translation>
+        <translation type="vanished">Peruuta</translation>
     </message>
 </context>
 <context>
@@ -878,144 +877,144 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>Tarvitseeko tämä tietokone välityspalvelimen internet-yhteyden luomista varten?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="69"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="70"/>
         <source>Proxy type:</source>
         <translation>Välityspalvelimen tyyppi:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="74"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="75"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="77"/>
         <source>None</source>
         <translation>Ei mitään</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="92"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="93"/>
         <source>If you need a proxy to access the internet, select one from this list.</source>
         <extracomment>Description used by accessibility tech, such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="97"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="98"/>
         <source>Address:</source>
         <extracomment>Label indicating the textbox to place a proxy IP or URL</extracomment>
         <translation>Osoite:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="111"/>
         <source>IP address or hostname</source>
         <extracomment>Placeholder text of text box expecting an IP or URL for proxy</extracomment>
         <translation>IP-osoite tai isäntä:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="115"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="116"/>
         <source>Enter the IP address or hostname of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the IP textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="119"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="120"/>
         <source>Port:</source>
         <extracomment>Label indicating the textbox to place a proxy port</extracomment>
         <translation>Portti:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="130"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="131"/>
         <source>Port</source>
         <extracomment>Name of the port label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="132"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="133"/>
         <source>Enter the port of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the Port textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="138"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="139"/>
         <source>Username:</source>
         <extracomment>Label indicating the textbox to place the proxy username</extracomment>
         <translation>Käyttäjänimi:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="152"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="173"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="153"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="174"/>
         <source>Optional</source>
         <extracomment>Textbox placeholder text indicating the field is not required</extracomment>
         <translation>Vaihtoehtoinen</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="156"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="157"/>
         <source>Username</source>
         <extracomment>Name of the username label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="158"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="159"/>
         <source>If required, enter the username for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Username textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="162"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="163"/>
         <source>Password:</source>
         <extracomment>Label indicating the textbox to place the proxy password</extracomment>
         <translation>Salasana:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="177"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="178"/>
         <source>Password</source>
         <extracomment>Name of the password label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="180"/>
         <source>If required, enter the password for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Password textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="190"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="191"/>
         <source>Does this computer&apos;s Internet connection go through a firewall that only allows connections to certain ports?</source>
         <extracomment>Description for the purpose of the Allowed Ports textbox</extracomment>
         <translation>Suojaako tämän tietokoneen internet-yhteyttä palomuuri, joka sallii liikenteen vain ennalta määrätyistä porteista?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="211"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="212"/>
         <source>Allowed ports:</source>
         <extracomment>Label indicating the textbox to place the allowed ports</extracomment>
         <translation>Sallitut portit:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="220"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="221"/>
         <source>Example: 80,443</source>
         <extracomment>Textbox showing an example entry for the firewall allowed ports entry</extracomment>
         <translation>Esimerkiksi: 80,443</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="224"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="225"/>
         <source>Allowed ports</source>
         <extracomment>Name of the allowed ports label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="236"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="237"/>
         <source>If this computer&apos;s Internet connection is censored, you will need to obtain and use bridge relays.</source>
         <translation>Jos tämän tietokoneen internet-yhteyttä on sensuroitu, sinun täytyy käyttää sillattuja reitittimiä</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="251"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="262"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="252"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="263"/>
         <source>Enter one or more bridge relays (one per line):</source>
         <translation>Anna yksi tai useampi reititin (erottele rivinvaihdolla):</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="273"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="274"/>
         <source>Back</source>
         <extracomment>Button label for going back to previous screen</extracomment>
         <translation>Palaa</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="284"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="285"/>
         <source>Connect</source>
         <extracomment>Button label for connecting to tor</extracomment>
         <translation>Yhdistä</translation>
@@ -1192,51 +1191,65 @@ Name of the button for launching the preferences window for accessibility tech l
     </message>
     <message>
         <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="114"/>
+        <source>Accepted</source>
+        <translation type="unfinished">Hyväksytty</translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="115"/>
         <source>Rejected</source>
         <translation type="unfinished">Torjuttu</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="120"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
         <source>Cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
         <source>Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
         <source>Unkown Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
         <source>Bad File Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
         <source>Network Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="126"/>
         <source>File System Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="127"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="128"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="220"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="223"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="395"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="285"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="289"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="295"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="309"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="350"/>
+        <source>me</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="436"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/tego_ui/translation/ricochet_fil_PH.ts
+++ b/src/tego_ui/translation/ricochet_fil_PH.ts
@@ -21,29 +21,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="36"/>
-        <source>Ricochet Refresh web home page</source>
-        <extracomment>provides context for the URL for accessibility tech like screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="59"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="32"/>
         <source>The license of Ricochet Refresh and its dependencies</source>
-        <extracomment>summary of a block of text for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="60"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="33"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="65"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="37"/>
         <source>About</source>
         <translation type="unfinished">Patungkol</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="39"/>
         <source>About page, contains license and version information</source>
         <extracomment>summary of the window&apos;s contents for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -105,37 +98,53 @@
 <context>
     <name>ContactActions</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="49"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <source>Could not successfully export conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="65"/>
         <source>Open Window</source>
         <extracomment>Context menu command to open the chat screen in a separate window</extracomment>
         <translation>Magbukas ng Window</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="70"/>
         <source>Details...</source>
         <extracomment>Context menu command to open a window showing the selected contact&apos;s details</extracomment>
         <translation>Detalye...</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="56"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="75"/>
         <source>Rename</source>
         <extracomment>Context menu command to rename the selected contact</extracomment>
         <translation>Palitan ang pangalan</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="61"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="80"/>
         <source>Send File...</source>
         <extracomment>Context menu command to initiate a file transfer, opens a system file dialog</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="85"/>
+        <source>Export Conversation</source>
+        <extracomment>Context menu command to initiate a chat log export, opens a system file dialog to export to</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="91"/>
         <source>Remove</source>
         <extracomment>Context menu command to remove a contact from the contact list</extracomment>
         <translation>Tanggalin</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="74"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="98"/>
         <source>Contact options</source>
         <extracomment>Description of the items in the context menu for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -151,30 +160,36 @@
     </message>
     <message>
         <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="45"/>
+        <source>This ID is invalid</source>
+        <extracomment>Error message showed when the id doesn&apos;t comply with spec https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
         <source>You can&apos;t add yourself as a contact</source>
         <extracomment>Error message showed when user attempts to add themselves as a contact in their contact list</extracomment>
         <translation>Hindi mo maaaring idagdag ang iyong sarili bilang isang contact</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="55"/>
         <source>Enter an ID starting with &lt;b&gt;ricochet:&lt;/b&gt;</source>
         <extracomment>Error message showed when the provided ricochet id is invalid</extracomment>
         <translation>Magpasok ng isang ID na nagsisimula sa &lt;b&gt;ricochet:&lt;/ b&gt;</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="88"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="97"/>
         <source>Copied to clipboard</source>
         <extracomment>Message displayed when text is copied to the user&apos;s clipboard</extracomment>
         <translation>Kinopya sa clipboard</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="103"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="112"/>
         <source>Copy</source>
         <extracomment>Text displayed on a button used to copy somethign to the user&apos;s clipboard</extracomment>
         <translation>Kopyahin</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="119"/>
         <source>Copies the ricochet id to the clipboard</source>
         <extracomment>Text description of ricochet id copy button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -393,20 +408,19 @@
         <translation>Gumamit ng solong window para sa mga pag-uusap</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Open links in default browser without prompting</source>
         <extracomment>Text description of an option to open URLs in default web browser when clicked</extracomment>
-        <translation>Buksan ang mga link sa default na browser nang walang pagdikta</translation>
+        <translation type="vanished">Buksan ang mga link sa default na browser nang walang pagdikta</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="44"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Play audio notifications</source>
         <extracomment>Text description of an option to play audio notifications when contacts log in, log out, and send messages</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="61"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="77"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="62"/>
         <source>Volume</source>
         <extracomment>Label for a slider used to adjust audio notification volume
 ----------
@@ -414,8 +428,8 @@ Name of the slider used to adjust audio notification volume for accessibility te
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="91"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="129"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="114"/>
         <source>Language</source>
         <extracomment>Label for combobox where users can specify the UI language
 ----------
@@ -423,12 +437,12 @@ Name of the combobox used to select UI langauge for accessibility tech like scre
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="117"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="102"/>
         <source>Restart Ricochet to apply changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="131"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="116"/>
         <source>What language ricochet will use</source>
         <extracomment>Description of what the language combox is for for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -492,17 +506,17 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="157"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="151"/>
         <source>Version Seperator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="191"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="185"/>
         <source>Remove %1</source>
         <translation>Tanggalin si %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="192"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="186"/>
         <source>Do you want to permanently remove %1?</source>
         <translation>Gusto mo bang permanenteng tanggalin si %1?</translation>
     </message>
@@ -534,79 +548,74 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>Si %1 ay offline</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="169"/>
         <source>File transfer file name</source>
         <extracomment>Description of the text displaying the filename of a file transfer, used by accessibility tech like screen readres</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="195"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="185"/>
         <source>File transfer progress</source>
         <extracomment>Description of progress bar displaying the file transfer progress, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="210"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="200"/>
         <source>File transfer status</source>
         <extracomment>Description of label displaying the current status of a file transfer, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="225"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="215"/>
         <source>Download</source>
         <extracomment>Label for file transfer &apos;Download&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="227"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="217"/>
         <source>Download file</source>
         <extracomment>Description of what the file transfer &apos;Download&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="244"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="234"/>
         <source>Cancel or reject</source>
         <extracomment>Label for file transfer &apos;Cancel&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="246"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="236"/>
         <source>Cancels or rejects a file transfer</source>
         <extracomment>Description of what the file transfer &apos;Cancel&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="310"/>
         <source>Copy ID</source>
         <extracomment>Text for context menu command to copy a ricochet contact id to clipboard</extracomment>
-        <translation>Kopyahin ang ID</translation>
+        <translation type="vanished">Kopyahin ang ID</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="281"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="312"/>
         <source>Copy Link</source>
         <extracomment>Text for context menu command to copy a url to the clipboard</extracomment>
-        <translation>Kopyahin ang Link</translation>
+        <translation type="vanished">Kopyahin ang Link</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="287"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="318"/>
         <source>Open with Browser</source>
         <extracomment>Text for context menu command to open a url in a web browser</extracomment>
-        <translation>Buksan gamit ang Browser</translation>
+        <translation type="vanished">Buksan gamit ang Browser</translation>
     </message>
     <message>
         <source>Add as Contact</source>
         <translation type="vanished">Idagdag bilang Contact</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="335"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="262"/>
         <source>Copy Message</source>
         <extracomment>Text for context menu command to copy an entire message to clipboard</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="343"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="270"/>
         <source>Copy Selection</source>
         <extracomment>Text for context menu command to copy selected text to clipboard</extracomment>
         <translation type="unfinished"></translation>
@@ -690,10 +699,9 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>OpenBrowserDialog</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="41"/>
         <source>&lt;b&gt;Warning!&lt;/b&gt; Opening links with your default browser will harm your security and anonymity.&lt;br&gt;&lt;br&gt;You can &lt;a href=&apos;.&apos;&gt;copy to the clipboard&lt;/a&gt; instead.</source>
         <extracomment>Label displayed when user clicks on a link</extracomment>
-        <translation>&lt;b&gt;Babala!&lt;/ b&gt; Pagbukas ng mga link gamit ang iyong default na browser ay makakapinsala sa iyong seguridad at anonymity.&lt;br&gt;
+        <translation type="vanished">&lt;b&gt;Babala!&lt;/ b&gt; Pagbukas ng mga link gamit ang iyong default na browser ay makakapinsala sa iyong seguridad at anonymity.&lt;br&gt;
 &lt;br&gt; Maaari mong &lt;a href=&apos;.&apos;&gt;kopyahin sa clipboard&lt;/a&gt; sa halip.</translation>
     </message>
     <message>
@@ -701,28 +709,19 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation type="vanished">Huwag nang tatanungin ulit para sa mga link mula kay %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="50"/>
-        <source>Warning</source>
-        <extracomment>Name of warning label used with accessibility tech such as screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="65"/>
         <source>Don&apos;t ask again for any links (not recommended!)</source>
         <extracomment>Checkbox option text for when user clicks on a link</extracomment>
-        <translation>Huwag nang tatanungin ulit para sa anumang mga link (hindi inirerekomenda!)</translation>
+        <translation type="vanished">Huwag nang tatanungin ulit para sa anumang mga link (hindi inirerekomenda!)</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="73"/>
         <source>Open Browser</source>
         <extracomment>Label on button to open link in a web browser</extracomment>
-        <translation>Buksan ang Browser</translation>
+        <translation type="vanished">Buksan ang Browser</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="84"/>
         <source>Cancel</source>
         <extracomment>Label on cancel button</extracomment>
-        <translation>Kanselahin</translation>
+        <translation type="vanished">Kanselahin</translation>
     </message>
 </context>
 <context>
@@ -860,144 +859,144 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>Kailangan ba ng computer na ito ng proxy upang ma-access ang internet?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="69"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="70"/>
         <source>Proxy type:</source>
         <translation>Uri ng Proxy:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="74"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="75"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="77"/>
         <source>None</source>
         <translation>Wala</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="92"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="93"/>
         <source>If you need a proxy to access the internet, select one from this list.</source>
         <extracomment>Description used by accessibility tech, such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="97"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="98"/>
         <source>Address:</source>
         <extracomment>Label indicating the textbox to place a proxy IP or URL</extracomment>
         <translation>Address:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="111"/>
         <source>IP address or hostname</source>
         <extracomment>Placeholder text of text box expecting an IP or URL for proxy</extracomment>
         <translation>IP address o hostname</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="115"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="116"/>
         <source>Enter the IP address or hostname of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the IP textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="119"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="120"/>
         <source>Port:</source>
         <extracomment>Label indicating the textbox to place a proxy port</extracomment>
         <translation>Port:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="130"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="131"/>
         <source>Port</source>
         <extracomment>Name of the port label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="132"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="133"/>
         <source>Enter the port of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the Port textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="138"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="139"/>
         <source>Username:</source>
         <extracomment>Label indicating the textbox to place the proxy username</extracomment>
         <translation>Username:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="152"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="173"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="153"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="174"/>
         <source>Optional</source>
         <extracomment>Textbox placeholder text indicating the field is not required</extracomment>
         <translation>Opsyonal</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="156"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="157"/>
         <source>Username</source>
         <extracomment>Name of the username label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="158"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="159"/>
         <source>If required, enter the username for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Username textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="162"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="163"/>
         <source>Password:</source>
         <extracomment>Label indicating the textbox to place the proxy password</extracomment>
         <translation>Password:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="177"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="178"/>
         <source>Password</source>
         <extracomment>Name of the password label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="180"/>
         <source>If required, enter the password for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Password textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="190"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="191"/>
         <source>Does this computer&apos;s Internet connection go through a firewall that only allows connections to certain ports?</source>
         <extracomment>Description for the purpose of the Allowed Ports textbox</extracomment>
         <translation>Pumupunta ba ang koneksyon sa Internet ng computer na ito sa pamamagitan ng isang firewall na nagbibigay-daan lamang ng mga koneksyon sa ilang mga ports?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="211"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="212"/>
         <source>Allowed ports:</source>
         <extracomment>Label indicating the textbox to place the allowed ports</extracomment>
         <translation>Pinayagan na ports:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="220"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="221"/>
         <source>Example: 80,443</source>
         <extracomment>Textbox showing an example entry for the firewall allowed ports entry</extracomment>
         <translation>Halimbawa: 80, 443</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="224"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="225"/>
         <source>Allowed ports</source>
         <extracomment>Name of the allowed ports label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="236"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="237"/>
         <source>If this computer&apos;s Internet connection is censored, you will need to obtain and use bridge relays.</source>
         <translation>Kung ang koneksyon sa Internet ng computer na ito ay censored, kakailanganin mo na makuha at gumamit ng bridge relays.</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="251"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="262"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="252"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="263"/>
         <source>Enter one or more bridge relays (one per line):</source>
         <translation>Magpasok ng isa o higit pang mga bridge relays (isa bawat linya):</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="273"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="274"/>
         <source>Back</source>
         <extracomment>Button label for going back to previous screen</extracomment>
         <translation>Bumalik</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="284"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="285"/>
         <source>Connect</source>
         <extracomment>Button label for connecting to tor</extracomment>
         <translation>Kumonekta</translation>
@@ -1174,51 +1173,65 @@ Name of the button for launching the preferences window for accessibility tech l
     </message>
     <message>
         <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="114"/>
+        <source>Accepted</source>
+        <translation type="unfinished">Natanggap</translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="115"/>
         <source>Rejected</source>
         <translation type="unfinished">Tinanggihan</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="120"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
         <source>Cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
         <source>Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
         <source>Unkown Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
         <source>Bad File Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
         <source>Network Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="126"/>
         <source>File System Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="127"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="128"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="220"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="223"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="395"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="285"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="289"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="295"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="309"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="350"/>
+        <source>me</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="436"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/tego_ui/translation/ricochet_fr.ts
+++ b/src/tego_ui/translation/ricochet_fr.ts
@@ -21,29 +21,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="36"/>
-        <source>Ricochet Refresh web home page</source>
-        <extracomment>provides context for the URL for accessibility tech like screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="59"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="32"/>
         <source>The license of Ricochet Refresh and its dependencies</source>
-        <extracomment>summary of a block of text for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="60"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="33"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="65"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="37"/>
         <source>About</source>
         <translation type="unfinished">À propos</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="39"/>
         <source>About page, contains license and version information</source>
         <extracomment>summary of the window&apos;s contents for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -105,37 +98,53 @@
 <context>
     <name>ContactActions</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="49"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <source>Could not successfully export conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="65"/>
         <source>Open Window</source>
         <extracomment>Context menu command to open the chat screen in a separate window</extracomment>
         <translation>Ouvrir la fenêtre</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="70"/>
         <source>Details...</source>
         <extracomment>Context menu command to open a window showing the selected contact&apos;s details</extracomment>
         <translation>Détails...</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="56"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="75"/>
         <source>Rename</source>
         <extracomment>Context menu command to rename the selected contact</extracomment>
         <translation>Renommer</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="61"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="80"/>
         <source>Send File...</source>
         <extracomment>Context menu command to initiate a file transfer, opens a system file dialog</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="85"/>
+        <source>Export Conversation</source>
+        <extracomment>Context menu command to initiate a chat log export, opens a system file dialog to export to</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="91"/>
         <source>Remove</source>
         <extracomment>Context menu command to remove a contact from the contact list</extracomment>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="74"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="98"/>
         <source>Contact options</source>
         <extracomment>Description of the items in the context menu for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -151,30 +160,36 @@
     </message>
     <message>
         <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="45"/>
+        <source>This ID is invalid</source>
+        <extracomment>Error message showed when the id doesn&apos;t comply with spec https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
         <source>You can&apos;t add yourself as a contact</source>
         <extracomment>Error message showed when user attempts to add themselves as a contact in their contact list</extracomment>
         <translation>Vous ne pouvez pas vous ajouter vous-même en tant que contact</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="55"/>
         <source>Enter an ID starting with &lt;b&gt;ricochet:&lt;/b&gt;</source>
         <extracomment>Error message showed when the provided ricochet id is invalid</extracomment>
         <translation>Entrez un ID commençant par &lt;b&gt;ricochet:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="88"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="97"/>
         <source>Copied to clipboard</source>
         <extracomment>Message displayed when text is copied to the user&apos;s clipboard</extracomment>
         <translation>Copié dans le presse-papier</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="103"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="112"/>
         <source>Copy</source>
         <extracomment>Text displayed on a button used to copy somethign to the user&apos;s clipboard</extracomment>
         <translation>Copier</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="119"/>
         <source>Copies the ricochet id to the clipboard</source>
         <extracomment>Text description of ricochet id copy button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -397,20 +412,19 @@
         <translation>Utiliser une seule fenêtre pour les conversations</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Open links in default browser without prompting</source>
         <extracomment>Text description of an option to open URLs in default web browser when clicked</extracomment>
-        <translation>Ouvrir les hyperliens directement dans le navigateur par défaut sans demander à chaque fois</translation>
+        <translation type="vanished">Ouvrir les hyperliens directement dans le navigateur par défaut sans demander à chaque fois</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="44"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Play audio notifications</source>
         <extracomment>Text description of an option to play audio notifications when contacts log in, log out, and send messages</extracomment>
         <translation>Jouer les notifications sonores</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="61"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="77"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="62"/>
         <source>Volume</source>
         <extracomment>Label for a slider used to adjust audio notification volume
 ----------
@@ -418,8 +432,8 @@ Name of the slider used to adjust audio notification volume for accessibility te
         <translation>Volume</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="91"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="129"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="114"/>
         <source>Language</source>
         <extracomment>Label for combobox where users can specify the UI language
 ----------
@@ -427,12 +441,12 @@ Name of the combobox used to select UI langauge for accessibility tech like scre
         <translation type="unfinished">Langue</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="117"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="102"/>
         <source>Restart Ricochet to apply changes</source>
         <translation type="unfinished">Redémarrer l&apos;application pour applique les modifications</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="131"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="116"/>
         <source>What language ricochet will use</source>
         <extracomment>Description of what the language combox is for for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -507,17 +521,17 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="157"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="151"/>
         <source>Version Seperator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="191"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="185"/>
         <source>Remove %1</source>
         <translation>Supprimer %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="192"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="186"/>
         <source>Do you want to permanently remove %1?</source>
         <translation>Voulez-vous supprimer %1 définitivement ?</translation>
     </message>
@@ -549,79 +563,74 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>%1 est hors-ligne</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="169"/>
         <source>File transfer file name</source>
         <extracomment>Description of the text displaying the filename of a file transfer, used by accessibility tech like screen readres</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="195"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="185"/>
         <source>File transfer progress</source>
         <extracomment>Description of progress bar displaying the file transfer progress, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="210"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="200"/>
         <source>File transfer status</source>
         <extracomment>Description of label displaying the current status of a file transfer, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="225"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="215"/>
         <source>Download</source>
         <extracomment>Label for file transfer &apos;Download&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="227"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="217"/>
         <source>Download file</source>
         <extracomment>Description of what the file transfer &apos;Download&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="244"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="234"/>
         <source>Cancel or reject</source>
         <extracomment>Label for file transfer &apos;Cancel&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="246"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="236"/>
         <source>Cancels or rejects a file transfer</source>
         <extracomment>Description of what the file transfer &apos;Cancel&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="310"/>
         <source>Copy ID</source>
         <extracomment>Text for context menu command to copy a ricochet contact id to clipboard</extracomment>
-        <translation>Copier ID</translation>
+        <translation type="vanished">Copier ID</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="281"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="312"/>
         <source>Copy Link</source>
         <extracomment>Text for context menu command to copy a url to the clipboard</extracomment>
-        <translation>Copier l&apos;hyperlien</translation>
+        <translation type="vanished">Copier l&apos;hyperlien</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="287"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="318"/>
         <source>Open with Browser</source>
         <extracomment>Text for context menu command to open a url in a web browser</extracomment>
-        <translation>Ouvrir avec le navigateur</translation>
+        <translation type="vanished">Ouvrir avec le navigateur</translation>
     </message>
     <message>
         <source>Add as Contact</source>
         <translation type="vanished">Ajouter comme contact</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="335"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="262"/>
         <source>Copy Message</source>
         <extracomment>Text for context menu command to copy an entire message to clipboard</extracomment>
         <translation>Copier le message</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="343"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="270"/>
         <source>Copy Selection</source>
         <extracomment>Text for context menu command to copy selected text to clipboard</extracomment>
         <translation>Copier la sélection</translation>
@@ -705,38 +714,28 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>OpenBrowserDialog</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="41"/>
         <source>&lt;b&gt;Warning!&lt;/b&gt; Opening links with your default browser will harm your security and anonymity.&lt;br&gt;&lt;br&gt;You can &lt;a href=&apos;.&apos;&gt;copy to the clipboard&lt;/a&gt; instead.</source>
         <extracomment>Label displayed when user clicks on a link</extracomment>
-        <translation>&lt;b&gt;Attention !&lt;/b&gt; Ouvrir des hyperliens avec votre navigateur par défaut pourrait nuire à votre sécurité et votre anonymat.&lt;br&gt;&lt;br&gt;Vous pouvez &lt;a href=&apos;.&apos;&gt;copier dans le presse-papier&lt;/a&gt; à la place.</translation>
+        <translation type="vanished">&lt;b&gt;Attention !&lt;/b&gt; Ouvrir des hyperliens avec votre navigateur par défaut pourrait nuire à votre sécurité et votre anonymat.&lt;br&gt;&lt;br&gt;Vous pouvez &lt;a href=&apos;.&apos;&gt;copier dans le presse-papier&lt;/a&gt; à la place.</translation>
     </message>
     <message>
         <source>Don&apos;t ask again for links from %1</source>
         <translation type="vanished">Ne plus demander pour des hyperliens provenant de %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="50"/>
-        <source>Warning</source>
-        <extracomment>Name of warning label used with accessibility tech such as screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="65"/>
         <source>Don&apos;t ask again for any links (not recommended!)</source>
         <extracomment>Checkbox option text for when user clicks on a link</extracomment>
-        <translation>Ne plus demander à nouveau pour tous les hyperliens (non recommandé)</translation>
+        <translation type="vanished">Ne plus demander à nouveau pour tous les hyperliens (non recommandé)</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="73"/>
         <source>Open Browser</source>
         <extracomment>Label on button to open link in a web browser</extracomment>
-        <translation>Ouvrir le navigateur</translation>
+        <translation type="vanished">Ouvrir le navigateur</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="84"/>
         <source>Cancel</source>
         <extracomment>Label on cancel button</extracomment>
-        <translation>Annuler</translation>
+        <translation type="vanished">Annuler</translation>
     </message>
 </context>
 <context>
@@ -878,144 +877,144 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>Est-ce que cet ordinateur à besoin d&apos;un proxy pour accéder à Internet ?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="69"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="70"/>
         <source>Proxy type:</source>
         <translation>Type de proxy :</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="74"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="75"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="77"/>
         <source>None</source>
         <translation>Aucun</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="92"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="93"/>
         <source>If you need a proxy to access the internet, select one from this list.</source>
         <extracomment>Description used by accessibility tech, such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="97"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="98"/>
         <source>Address:</source>
         <extracomment>Label indicating the textbox to place a proxy IP or URL</extracomment>
         <translation>Adresse : </translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="111"/>
         <source>IP address or hostname</source>
         <extracomment>Placeholder text of text box expecting an IP or URL for proxy</extracomment>
         <translation>Adresse IP ou nom d&apos;hôte</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="115"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="116"/>
         <source>Enter the IP address or hostname of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the IP textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="119"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="120"/>
         <source>Port:</source>
         <extracomment>Label indicating the textbox to place a proxy port</extracomment>
         <translation>Port : </translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="130"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="131"/>
         <source>Port</source>
         <extracomment>Name of the port label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="132"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="133"/>
         <source>Enter the port of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the Port textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="138"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="139"/>
         <source>Username:</source>
         <extracomment>Label indicating the textbox to place the proxy username</extracomment>
         <translation>Nom d&apos;utilisateur : </translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="152"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="173"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="153"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="174"/>
         <source>Optional</source>
         <extracomment>Textbox placeholder text indicating the field is not required</extracomment>
         <translation>En option</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="156"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="157"/>
         <source>Username</source>
         <extracomment>Name of the username label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="158"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="159"/>
         <source>If required, enter the username for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Username textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="162"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="163"/>
         <source>Password:</source>
         <extracomment>Label indicating the textbox to place the proxy password</extracomment>
         <translation>Mot de passe : </translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="177"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="178"/>
         <source>Password</source>
         <extracomment>Name of the password label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="180"/>
         <source>If required, enter the password for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Password textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="190"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="191"/>
         <source>Does this computer&apos;s Internet connection go through a firewall that only allows connections to certain ports?</source>
         <extracomment>Description for the purpose of the Allowed Ports textbox</extracomment>
         <translation>Est-ce que la connexion Internet de cet ordinateur passe à travers un pare-feu qui autorise uniquement les connexions à certains ports ?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="211"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="212"/>
         <source>Allowed ports:</source>
         <extracomment>Label indicating the textbox to place the allowed ports</extracomment>
         <translation>Ports autorisés :</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="220"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="221"/>
         <source>Example: 80,443</source>
         <extracomment>Textbox showing an example entry for the firewall allowed ports entry</extracomment>
         <translation>Exemple : 80,443</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="224"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="225"/>
         <source>Allowed ports</source>
         <extracomment>Name of the allowed ports label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="236"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="237"/>
         <source>If this computer&apos;s Internet connection is censored, you will need to obtain and use bridge relays.</source>
         <translation>Si la connexion Internet de cet ordinateur est censurée, vous allez devoir obtenir et utiliser un pont Tor.</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="251"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="262"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="252"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="263"/>
         <source>Enter one or more bridge relays (one per line):</source>
         <translation>Entrez un ou plusieurs ponts Tor (un par ligne) :</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="273"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="274"/>
         <source>Back</source>
         <extracomment>Button label for going back to previous screen</extracomment>
         <translation>Retour</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="284"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="285"/>
         <source>Connect</source>
         <extracomment>Button label for connecting to tor</extracomment>
         <translation>Connexion</translation>
@@ -1192,51 +1191,65 @@ Name of the button for launching the preferences window for accessibility tech l
     </message>
     <message>
         <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="114"/>
+        <source>Accepted</source>
+        <translation type="unfinished">Accepté</translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="115"/>
         <source>Rejected</source>
         <translation type="unfinished">Rejeté</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="120"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
         <source>Cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
         <source>Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
         <source>Unkown Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
         <source>Bad File Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
         <source>Network Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="126"/>
         <source>File System Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="127"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="128"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="220"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="223"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="395"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="285"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="289"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="295"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="309"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="350"/>
+        <source>me</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="436"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/tego_ui/translation/ricochet_he.ts
+++ b/src/tego_ui/translation/ricochet_he.ts
@@ -21,29 +21,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="36"/>
-        <source>Ricochet Refresh web home page</source>
-        <extracomment>provides context for the URL for accessibility tech like screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="59"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="32"/>
         <source>The license of Ricochet Refresh and its dependencies</source>
-        <extracomment>summary of a block of text for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="60"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="33"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="65"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="37"/>
         <source>About</source>
         <translation type="unfinished">אודות</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="39"/>
         <source>About page, contains license and version information</source>
         <extracomment>summary of the window&apos;s contents for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -105,37 +98,53 @@
 <context>
     <name>ContactActions</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="49"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <source>Could not successfully export conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="65"/>
         <source>Open Window</source>
         <extracomment>Context menu command to open the chat screen in a separate window</extracomment>
         <translation>פתח חלון</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="70"/>
         <source>Details...</source>
         <extracomment>Context menu command to open a window showing the selected contact&apos;s details</extracomment>
         <translation>פרטים נוספים...</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="56"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="75"/>
         <source>Rename</source>
         <extracomment>Context menu command to rename the selected contact</extracomment>
         <translation>שנה שם</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="61"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="80"/>
         <source>Send File...</source>
         <extracomment>Context menu command to initiate a file transfer, opens a system file dialog</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="85"/>
+        <source>Export Conversation</source>
+        <extracomment>Context menu command to initiate a chat log export, opens a system file dialog to export to</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="91"/>
         <source>Remove</source>
         <extracomment>Context menu command to remove a contact from the contact list</extracomment>
         <translation>מחק</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="74"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="98"/>
         <source>Contact options</source>
         <extracomment>Description of the items in the context menu for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -151,30 +160,36 @@
     </message>
     <message>
         <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="45"/>
+        <source>This ID is invalid</source>
+        <extracomment>Error message showed when the id doesn&apos;t comply with spec https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
         <source>You can&apos;t add yourself as a contact</source>
         <extracomment>Error message showed when user attempts to add themselves as a contact in their contact list</extracomment>
         <translation>אי אפשר להוסיף עצמך לאנשי קשר</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="55"/>
         <source>Enter an ID starting with &lt;b&gt;ricochet:&lt;/b&gt;</source>
         <extracomment>Error message showed when the provided ricochet id is invalid</extracomment>
         <translation>הכנס שם משתמש אשר מתחיל ב &lt;b&gt;ricochet:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="88"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="97"/>
         <source>Copied to clipboard</source>
         <extracomment>Message displayed when text is copied to the user&apos;s clipboard</extracomment>
         <translation>הועתק ללוח</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="103"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="112"/>
         <source>Copy</source>
         <extracomment>Text displayed on a button used to copy somethign to the user&apos;s clipboard</extracomment>
         <translation>העתק</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="119"/>
         <source>Copies the ricochet id to the clipboard</source>
         <extracomment>Text description of ricochet id copy button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -397,20 +412,19 @@
         <translation>השתמש בחלון בודד עבור כל השיחות</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Open links in default browser without prompting</source>
         <extracomment>Text description of an option to open URLs in default web browser when clicked</extracomment>
-        <translation>פתח קישורים בדפדפן ברירת המחדל ללא בקשת אישור</translation>
+        <translation type="vanished">פתח קישורים בדפדפן ברירת המחדל ללא בקשת אישור</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="44"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Play audio notifications</source>
         <extracomment>Text description of an option to play audio notifications when contacts log in, log out, and send messages</extracomment>
         <translation>השמע התראה קולית</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="61"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="77"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="62"/>
         <source>Volume</source>
         <extracomment>Label for a slider used to adjust audio notification volume
 ----------
@@ -418,8 +432,8 @@ Name of the slider used to adjust audio notification volume for accessibility te
         <translation>עוצמה</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="91"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="129"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="114"/>
         <source>Language</source>
         <extracomment>Label for combobox where users can specify the UI language
 ----------
@@ -427,12 +441,12 @@ Name of the combobox used to select UI langauge for accessibility tech like scre
         <translation type="unfinished">שפה</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="117"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="102"/>
         <source>Restart Ricochet to apply changes</source>
         <translation type="unfinished">הפעל מחדש את האפליקציה על מנת לעדכן את ההגדרות החדשות</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="131"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="116"/>
         <source>What language ricochet will use</source>
         <extracomment>Description of what the language combox is for for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -507,17 +521,17 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="157"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="151"/>
         <source>Version Seperator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="191"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="185"/>
         <source>Remove %1</source>
         <translation>הסר את %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="192"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="186"/>
         <source>Do you want to permanently remove %1?</source>
         <translation>האם אתה רוצה להסיר לצמיתות את %1</translation>
     </message>
@@ -549,79 +563,74 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>%1 מנותק</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="169"/>
         <source>File transfer file name</source>
         <extracomment>Description of the text displaying the filename of a file transfer, used by accessibility tech like screen readres</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="195"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="185"/>
         <source>File transfer progress</source>
         <extracomment>Description of progress bar displaying the file transfer progress, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="210"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="200"/>
         <source>File transfer status</source>
         <extracomment>Description of label displaying the current status of a file transfer, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="225"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="215"/>
         <source>Download</source>
         <extracomment>Label for file transfer &apos;Download&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="227"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="217"/>
         <source>Download file</source>
         <extracomment>Description of what the file transfer &apos;Download&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="244"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="234"/>
         <source>Cancel or reject</source>
         <extracomment>Label for file transfer &apos;Cancel&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="246"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="236"/>
         <source>Cancels or rejects a file transfer</source>
         <extracomment>Description of what the file transfer &apos;Cancel&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="310"/>
         <source>Copy ID</source>
         <extracomment>Text for context menu command to copy a ricochet contact id to clipboard</extracomment>
-        <translation>העתק זהות</translation>
+        <translation type="vanished">העתק זהות</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="281"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="312"/>
         <source>Copy Link</source>
         <extracomment>Text for context menu command to copy a url to the clipboard</extracomment>
-        <translation>העתק לינק</translation>
+        <translation type="vanished">העתק לינק</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="287"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="318"/>
         <source>Open with Browser</source>
         <extracomment>Text for context menu command to open a url in a web browser</extracomment>
-        <translation>פתח בדפדפן</translation>
+        <translation type="vanished">פתח בדפדפן</translation>
     </message>
     <message>
         <source>Add as Contact</source>
         <translation type="vanished">הוסיף כאיש קשר</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="335"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="262"/>
         <source>Copy Message</source>
         <extracomment>Text for context menu command to copy an entire message to clipboard</extracomment>
         <translation>העתק הודעה</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="343"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="270"/>
         <source>Copy Selection</source>
         <extracomment>Text for context menu command to copy selected text to clipboard</extracomment>
         <translation>העתק בחירה</translation>
@@ -705,38 +714,28 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>OpenBrowserDialog</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="41"/>
         <source>&lt;b&gt;Warning!&lt;/b&gt; Opening links with your default browser will harm your security and anonymity.&lt;br&gt;&lt;br&gt;You can &lt;a href=&apos;.&apos;&gt;copy to the clipboard&lt;/a&gt; instead.</source>
         <extracomment>Label displayed when user clicks on a link</extracomment>
-        <translation>&lt;b&gt;זהירות!&lt;/b&gt; פתיחת קישורים עם דפדפן הברירת מחדל שלך עלולה לסכן אותך ולחשוף פרטים עלייך!&lt;br&gt;&lt;br&gt;תוכל במקום &lt;a href=&quot;.&quot;&gt;להעתיק את הקישור&lt;/a&gt; ללוח.</translation>
+        <translation type="vanished">&lt;b&gt;זהירות!&lt;/b&gt; פתיחת קישורים עם דפדפן הברירת מחדל שלך עלולה לסכן אותך ולחשוף פרטים עלייך!&lt;br&gt;&lt;br&gt;תוכל במקום &lt;a href=&quot;.&quot;&gt;להעתיק את הקישור&lt;/a&gt; ללוח.</translation>
     </message>
     <message>
         <source>Don&apos;t ask again for links from %1</source>
         <translation type="vanished">אין צורך לבקש אישור פתיחה נוסף מ %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="50"/>
-        <source>Warning</source>
-        <extracomment>Name of warning label used with accessibility tech such as screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="65"/>
         <source>Don&apos;t ask again for any links (not recommended!)</source>
         <extracomment>Checkbox option text for when user clicks on a link</extracomment>
-        <translation>אין צורך לבקש אישור מאף איש קשר (לא מומלץ ומסוכן!)</translation>
+        <translation type="vanished">אין צורך לבקש אישור מאף איש קשר (לא מומלץ ומסוכן!)</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="73"/>
         <source>Open Browser</source>
         <extracomment>Label on button to open link in a web browser</extracomment>
-        <translation>פתח דפדפן</translation>
+        <translation type="vanished">פתח דפדפן</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="84"/>
         <source>Cancel</source>
         <extracomment>Label on cancel button</extracomment>
-        <translation>בטל</translation>
+        <translation type="vanished">בטל</translation>
     </message>
 </context>
 <context>
@@ -878,144 +877,144 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>האם מחשב זה משתמש בפרוקסי על מנת להתחבר לאינטרנט?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="69"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="70"/>
         <source>Proxy type:</source>
         <translation>סוג פרוקסי</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="74"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="75"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="77"/>
         <source>None</source>
         <translation>ללא</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="92"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="93"/>
         <source>If you need a proxy to access the internet, select one from this list.</source>
         <extracomment>Description used by accessibility tech, such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="97"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="98"/>
         <source>Address:</source>
         <extracomment>Label indicating the textbox to place a proxy IP or URL</extracomment>
         <translation>כתובת:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="111"/>
         <source>IP address or hostname</source>
         <extracomment>Placeholder text of text box expecting an IP or URL for proxy</extracomment>
         <translation>כתובת IP או שם מחשב מארח</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="115"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="116"/>
         <source>Enter the IP address or hostname of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the IP textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="119"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="120"/>
         <source>Port:</source>
         <extracomment>Label indicating the textbox to place a proxy port</extracomment>
         <translation>פורט:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="130"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="131"/>
         <source>Port</source>
         <extracomment>Name of the port label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="132"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="133"/>
         <source>Enter the port of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the Port textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="138"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="139"/>
         <source>Username:</source>
         <extracomment>Label indicating the textbox to place the proxy username</extracomment>
         <translation>שם משתמש:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="152"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="173"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="153"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="174"/>
         <source>Optional</source>
         <extracomment>Textbox placeholder text indicating the field is not required</extracomment>
         <translation>אופציונלי</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="156"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="157"/>
         <source>Username</source>
         <extracomment>Name of the username label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="158"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="159"/>
         <source>If required, enter the username for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Username textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="162"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="163"/>
         <source>Password:</source>
         <extracomment>Label indicating the textbox to place the proxy password</extracomment>
         <translation>סיסמה:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="177"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="178"/>
         <source>Password</source>
         <extracomment>Name of the password label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="180"/>
         <source>If required, enter the password for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Password textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="190"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="191"/>
         <source>Does this computer&apos;s Internet connection go through a firewall that only allows connections to certain ports?</source>
         <extracomment>Description for the purpose of the Allowed Ports textbox</extracomment>
         <translation>האם חיבור של מחשב זה עובר דרך חומת אש אשר מרשה שימוש בפורטים מסויימים?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="211"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="212"/>
         <source>Allowed ports:</source>
         <extracomment>Label indicating the textbox to place the allowed ports</extracomment>
         <translation>פורטים מורשים:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="220"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="221"/>
         <source>Example: 80,443</source>
         <extracomment>Textbox showing an example entry for the firewall allowed ports entry</extracomment>
         <translation>דוגמה: 80,443</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="224"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="225"/>
         <source>Allowed ports</source>
         <extracomment>Name of the allowed ports label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="236"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="237"/>
         <source>If this computer&apos;s Internet connection is censored, you will need to obtain and use bridge relays.</source>
         <translation>במידה וחיבור האינטרנט של מחשב זה מצונזר, יהיה עליך להגדיר שרתי גישור חיבור</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="251"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="262"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="252"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="263"/>
         <source>Enter one or more bridge relays (one per line):</source>
         <translation>הכנס גשר חיבור (אחד לשורה):</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="273"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="274"/>
         <source>Back</source>
         <extracomment>Button label for going back to previous screen</extracomment>
         <translation>חזרה</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="284"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="285"/>
         <source>Connect</source>
         <extracomment>Button label for connecting to tor</extracomment>
         <translation>התחברהתחבר</translation>
@@ -1192,51 +1191,65 @@ Name of the button for launching the preferences window for accessibility tech l
     </message>
     <message>
         <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="114"/>
+        <source>Accepted</source>
+        <translation type="unfinished">התקבל</translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="115"/>
         <source>Rejected</source>
         <translation type="unfinished">קשרים שנדחו</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="120"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
         <source>Cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
         <source>Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
         <source>Unkown Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
         <source>Bad File Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
         <source>Network Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="126"/>
         <source>File System Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="127"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="128"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="220"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="223"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="395"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="285"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="289"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="295"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="309"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="350"/>
+        <source>me</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="436"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/tego_ui/translation/ricochet_it.ts
+++ b/src/tego_ui/translation/ricochet_it.ts
@@ -21,29 +21,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="36"/>
-        <source>Ricochet Refresh web home page</source>
-        <extracomment>provides context for the URL for accessibility tech like screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="59"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="32"/>
         <source>The license of Ricochet Refresh and its dependencies</source>
-        <extracomment>summary of a block of text for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="60"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="33"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="65"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="37"/>
         <source>About</source>
         <translation type="unfinished">Riguardo a </translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="39"/>
         <source>About page, contains license and version information</source>
         <extracomment>summary of the window&apos;s contents for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -105,37 +98,53 @@
 <context>
     <name>ContactActions</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="49"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <source>Could not successfully export conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="65"/>
         <source>Open Window</source>
         <extracomment>Context menu command to open the chat screen in a separate window</extracomment>
         <translation>Apri Finestra</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="70"/>
         <source>Details...</source>
         <extracomment>Context menu command to open a window showing the selected contact&apos;s details</extracomment>
         <translation>Dettagli...</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="56"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="75"/>
         <source>Rename</source>
         <extracomment>Context menu command to rename the selected contact</extracomment>
         <translation>Rinominare</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="61"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="80"/>
         <source>Send File...</source>
         <extracomment>Context menu command to initiate a file transfer, opens a system file dialog</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="85"/>
+        <source>Export Conversation</source>
+        <extracomment>Context menu command to initiate a chat log export, opens a system file dialog to export to</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="91"/>
         <source>Remove</source>
         <extracomment>Context menu command to remove a contact from the contact list</extracomment>
         <translation>Rimuovere</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="74"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="98"/>
         <source>Contact options</source>
         <extracomment>Description of the items in the context menu for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -151,30 +160,36 @@
     </message>
     <message>
         <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="45"/>
+        <source>This ID is invalid</source>
+        <extracomment>Error message showed when the id doesn&apos;t comply with spec https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
         <source>You can&apos;t add yourself as a contact</source>
         <extracomment>Error message showed when user attempts to add themselves as a contact in their contact list</extracomment>
         <translation>Non puoi aggiungere te stesso come contatto</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="55"/>
         <source>Enter an ID starting with &lt;b&gt;ricochet:&lt;/b&gt;</source>
         <extracomment>Error message showed when the provided ricochet id is invalid</extracomment>
         <translation>Inserisci un ID che inizi con &lt;b&gt;ricochet:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="88"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="97"/>
         <source>Copied to clipboard</source>
         <extracomment>Message displayed when text is copied to the user&apos;s clipboard</extracomment>
         <translation>Copiato negli appunti</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="103"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="112"/>
         <source>Copy</source>
         <extracomment>Text displayed on a button used to copy somethign to the user&apos;s clipboard</extracomment>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="119"/>
         <source>Copies the ricochet id to the clipboard</source>
         <extracomment>Text description of ricochet id copy button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -393,20 +408,19 @@
         <translation>Usa una finestra singola per le conversazioni</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Open links in default browser without prompting</source>
         <extracomment>Text description of an option to open URLs in default web browser when clicked</extracomment>
-        <translation>Apri link nel browser di default senza chiedere</translation>
+        <translation type="vanished">Apri link nel browser di default senza chiedere</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="44"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Play audio notifications</source>
         <extracomment>Text description of an option to play audio notifications when contacts log in, log out, and send messages</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="61"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="77"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="62"/>
         <source>Volume</source>
         <extracomment>Label for a slider used to adjust audio notification volume
 ----------
@@ -414,8 +428,8 @@ Name of the slider used to adjust audio notification volume for accessibility te
         <translation>Volume</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="91"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="129"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="114"/>
         <source>Language</source>
         <extracomment>Label for combobox where users can specify the UI language
 ----------
@@ -423,12 +437,12 @@ Name of the combobox used to select UI langauge for accessibility tech like scre
         <translation type="unfinished">Lingua</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="117"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="102"/>
         <source>Restart Ricochet to apply changes</source>
         <translation type="unfinished">Riavvia Ricochet per applicare le modifiche</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="131"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="116"/>
         <source>What language ricochet will use</source>
         <extracomment>Description of what the language combox is for for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -503,17 +517,17 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="157"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="151"/>
         <source>Version Seperator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="191"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="185"/>
         <source>Remove %1</source>
         <translation>Rimuovere %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="192"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="186"/>
         <source>Do you want to permanently remove %1?</source>
         <translation>Vuoi rimuovere perennemente %1?</translation>
     </message>
@@ -545,79 +559,74 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>%1 è sconnesso</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="169"/>
         <source>File transfer file name</source>
         <extracomment>Description of the text displaying the filename of a file transfer, used by accessibility tech like screen readres</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="195"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="185"/>
         <source>File transfer progress</source>
         <extracomment>Description of progress bar displaying the file transfer progress, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="210"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="200"/>
         <source>File transfer status</source>
         <extracomment>Description of label displaying the current status of a file transfer, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="225"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="215"/>
         <source>Download</source>
         <extracomment>Label for file transfer &apos;Download&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="227"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="217"/>
         <source>Download file</source>
         <extracomment>Description of what the file transfer &apos;Download&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="244"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="234"/>
         <source>Cancel or reject</source>
         <extracomment>Label for file transfer &apos;Cancel&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="246"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="236"/>
         <source>Cancels or rejects a file transfer</source>
         <extracomment>Description of what the file transfer &apos;Cancel&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="310"/>
         <source>Copy ID</source>
         <extracomment>Text for context menu command to copy a ricochet contact id to clipboard</extracomment>
-        <translation>Copia ID</translation>
+        <translation type="vanished">Copia ID</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="281"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="312"/>
         <source>Copy Link</source>
         <extracomment>Text for context menu command to copy a url to the clipboard</extracomment>
-        <translation>Copia Link</translation>
+        <translation type="vanished">Copia Link</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="287"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="318"/>
         <source>Open with Browser</source>
         <extracomment>Text for context menu command to open a url in a web browser</extracomment>
-        <translation>Apri con il Browser</translation>
+        <translation type="vanished">Apri con il Browser</translation>
     </message>
     <message>
         <source>Add as Contact</source>
         <translation type="vanished">Aggiungi come Contatto</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="335"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="262"/>
         <source>Copy Message</source>
         <extracomment>Text for context menu command to copy an entire message to clipboard</extracomment>
         <translation>Copia messaggio</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="343"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="270"/>
         <source>Copy Selection</source>
         <extracomment>Text for context menu command to copy selected text to clipboard</extracomment>
         <translation>Copia selezione</translation>
@@ -701,38 +710,28 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>OpenBrowserDialog</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="41"/>
         <source>&lt;b&gt;Warning!&lt;/b&gt; Opening links with your default browser will harm your security and anonymity.&lt;br&gt;&lt;br&gt;You can &lt;a href=&apos;.&apos;&gt;copy to the clipboard&lt;/a&gt; instead.</source>
         <extracomment>Label displayed when user clicks on a link</extracomment>
-        <translation>&lt;b&gt;Attenzione!&lt;/b&gt; Aprire link con il tuo browser di default danneggerà la tua sicurezza e anonimia.&lt;br&gt;&lt;br&gt;Puoi &lt;a href=&apos;.&apos;&gt;copiare negli appunti&lt;/a&gt; invece.</translation>
+        <translation type="vanished">&lt;b&gt;Attenzione!&lt;/b&gt; Aprire link con il tuo browser di default danneggerà la tua sicurezza e anonimia.&lt;br&gt;&lt;br&gt;Puoi &lt;a href=&apos;.&apos;&gt;copiare negli appunti&lt;/a&gt; invece.</translation>
     </message>
     <message>
         <source>Don&apos;t ask again for links from %1</source>
         <translation type="vanished">Non chiedere ancora per link da %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="50"/>
-        <source>Warning</source>
-        <extracomment>Name of warning label used with accessibility tech such as screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="65"/>
         <source>Don&apos;t ask again for any links (not recommended!)</source>
         <extracomment>Checkbox option text for when user clicks on a link</extracomment>
-        <translation>Non chiedere più per ogni link (non raccomandato)</translation>
+        <translation type="vanished">Non chiedere più per ogni link (non raccomandato)</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="73"/>
         <source>Open Browser</source>
         <extracomment>Label on button to open link in a web browser</extracomment>
-        <translation>Apri Browser</translation>
+        <translation type="vanished">Apri Browser</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="84"/>
         <source>Cancel</source>
         <extracomment>Label on cancel button</extracomment>
-        <translation>Annulla</translation>
+        <translation type="vanished">Annulla</translation>
     </message>
 </context>
 <context>
@@ -874,144 +873,144 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>Questo computer necessita di un proxy per accedere a internet?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="69"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="70"/>
         <source>Proxy type:</source>
         <translation>Tipo di proxy:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="74"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="75"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="77"/>
         <source>None</source>
         <translation>Nessuno</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="92"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="93"/>
         <source>If you need a proxy to access the internet, select one from this list.</source>
         <extracomment>Description used by accessibility tech, such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="97"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="98"/>
         <source>Address:</source>
         <extracomment>Label indicating the textbox to place a proxy IP or URL</extracomment>
         <translation>Indirizzo:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="111"/>
         <source>IP address or hostname</source>
         <extracomment>Placeholder text of text box expecting an IP or URL for proxy</extracomment>
         <translation>Indirizzo IP o nome host</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="115"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="116"/>
         <source>Enter the IP address or hostname of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the IP textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="119"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="120"/>
         <source>Port:</source>
         <extracomment>Label indicating the textbox to place a proxy port</extracomment>
         <translation>Porta:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="130"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="131"/>
         <source>Port</source>
         <extracomment>Name of the port label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="132"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="133"/>
         <source>Enter the port of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the Port textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="138"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="139"/>
         <source>Username:</source>
         <extracomment>Label indicating the textbox to place the proxy username</extracomment>
         <translation>Nome utente:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="152"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="173"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="153"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="174"/>
         <source>Optional</source>
         <extracomment>Textbox placeholder text indicating the field is not required</extracomment>
         <translation>Opzionale</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="156"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="157"/>
         <source>Username</source>
         <extracomment>Name of the username label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="158"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="159"/>
         <source>If required, enter the username for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Username textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="162"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="163"/>
         <source>Password:</source>
         <extracomment>Label indicating the textbox to place the proxy password</extracomment>
         <translation>Password:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="177"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="178"/>
         <source>Password</source>
         <extracomment>Name of the password label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="180"/>
         <source>If required, enter the password for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Password textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="190"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="191"/>
         <source>Does this computer&apos;s Internet connection go through a firewall that only allows connections to certain ports?</source>
         <extracomment>Description for the purpose of the Allowed Ports textbox</extracomment>
         <translation>La connessione di questo computer passa attraverso un firewall che permette la connessione solo ad alcune porte?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="211"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="212"/>
         <source>Allowed ports:</source>
         <extracomment>Label indicating the textbox to place the allowed ports</extracomment>
         <translation>Porte permesse:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="220"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="221"/>
         <source>Example: 80,443</source>
         <extracomment>Textbox showing an example entry for the firewall allowed ports entry</extracomment>
         <translation>Esempio: 80,443</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="224"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="225"/>
         <source>Allowed ports</source>
         <extracomment>Name of the allowed ports label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="236"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="237"/>
         <source>If this computer&apos;s Internet connection is censored, you will need to obtain and use bridge relays.</source>
         <translation>Se la connessione a internet di questo computer è censurata dovrai ottenere ed usare dei bridge relay</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="251"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="262"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="252"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="263"/>
         <source>Enter one or more bridge relays (one per line):</source>
         <translation>Inserisci uno o più bridge relay (uno per linea):</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="273"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="274"/>
         <source>Back</source>
         <extracomment>Button label for going back to previous screen</extracomment>
         <translation>Indietro</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="284"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="285"/>
         <source>Connect</source>
         <extracomment>Button label for connecting to tor</extracomment>
         <translation>Collegare</translation>
@@ -1188,51 +1187,65 @@ Name of the button for launching the preferences window for accessibility tech l
     </message>
     <message>
         <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="114"/>
+        <source>Accepted</source>
+        <translation type="unfinished">Accettato</translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="115"/>
         <source>Rejected</source>
         <translation type="unfinished">Rifiutato</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="120"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
         <source>Cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
         <source>Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
         <source>Unkown Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
         <source>Bad File Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
         <source>Network Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="126"/>
         <source>File System Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="127"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="128"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="220"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="223"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="395"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="285"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="289"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="295"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="309"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="350"/>
+        <source>me</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="436"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/tego_ui/translation/ricochet_it_IT.ts
+++ b/src/tego_ui/translation/ricochet_it_IT.ts
@@ -21,29 +21,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="36"/>
-        <source>Ricochet Refresh web home page</source>
-        <extracomment>provides context for the URL for accessibility tech like screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="59"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="32"/>
         <source>The license of Ricochet Refresh and its dependencies</source>
-        <extracomment>summary of a block of text for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="60"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="33"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="65"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="37"/>
         <source>About</source>
         <translation type="unfinished">Info</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="39"/>
         <source>About page, contains license and version information</source>
         <extracomment>summary of the window&apos;s contents for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -105,37 +98,53 @@
 <context>
     <name>ContactActions</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="49"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <source>Could not successfully export conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="65"/>
         <source>Open Window</source>
         <extracomment>Context menu command to open the chat screen in a separate window</extracomment>
         <translation>Apri finestra</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="70"/>
         <source>Details...</source>
         <extracomment>Context menu command to open a window showing the selected contact&apos;s details</extracomment>
         <translation>Dettagli...</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="56"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="75"/>
         <source>Rename</source>
         <extracomment>Context menu command to rename the selected contact</extracomment>
         <translation>Rinomina</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="61"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="80"/>
         <source>Send File...</source>
         <extracomment>Context menu command to initiate a file transfer, opens a system file dialog</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="85"/>
+        <source>Export Conversation</source>
+        <extracomment>Context menu command to initiate a chat log export, opens a system file dialog to export to</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="91"/>
         <source>Remove</source>
         <extracomment>Context menu command to remove a contact from the contact list</extracomment>
         <translation>Rimuovi</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="74"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="98"/>
         <source>Contact options</source>
         <extracomment>Description of the items in the context menu for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -151,30 +160,36 @@
     </message>
     <message>
         <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="45"/>
+        <source>This ID is invalid</source>
+        <extracomment>Error message showed when the id doesn&apos;t comply with spec https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
         <source>You can&apos;t add yourself as a contact</source>
         <extracomment>Error message showed when user attempts to add themselves as a contact in their contact list</extracomment>
         <translation>Non puoi aggiungere te stesso ai tuoi contatti</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="55"/>
         <source>Enter an ID starting with &lt;b&gt;ricochet:&lt;/b&gt;</source>
         <extracomment>Error message showed when the provided ricochet id is invalid</extracomment>
         <translation>Inserisci un ID che inizi con &lt;b&gt;ricochet:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="88"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="97"/>
         <source>Copied to clipboard</source>
         <extracomment>Message displayed when text is copied to the user&apos;s clipboard</extracomment>
         <translation>Copiato negli appunti</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="103"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="112"/>
         <source>Copy</source>
         <extracomment>Text displayed on a button used to copy somethign to the user&apos;s clipboard</extracomment>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="119"/>
         <source>Copies the ricochet id to the clipboard</source>
         <extracomment>Text description of ricochet id copy button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -397,20 +412,19 @@
         <translation>Usa una finestra singola per le conversazioni</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Open links in default browser without prompting</source>
         <extracomment>Text description of an option to open URLs in default web browser when clicked</extracomment>
-        <translation>Apri i link nel browser di default senza chiedere</translation>
+        <translation type="vanished">Apri i link nel browser di default senza chiedere</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="44"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Play audio notifications</source>
         <extracomment>Text description of an option to play audio notifications when contacts log in, log out, and send messages</extracomment>
         <translation>Riproduci suono notifiche</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="61"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="77"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="62"/>
         <source>Volume</source>
         <extracomment>Label for a slider used to adjust audio notification volume
 ----------
@@ -418,8 +432,8 @@ Name of the slider used to adjust audio notification volume for accessibility te
         <translation>Volume</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="91"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="129"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="114"/>
         <source>Language</source>
         <extracomment>Label for combobox where users can specify the UI language
 ----------
@@ -427,12 +441,12 @@ Name of the combobox used to select UI langauge for accessibility tech like scre
         <translation type="unfinished">Lingua</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="117"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="102"/>
         <source>Restart Ricochet to apply changes</source>
         <translation type="unfinished">Riavvia Ricochet per applicare le modifiche</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="131"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="116"/>
         <source>What language ricochet will use</source>
         <extracomment>Description of what the language combox is for for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -507,17 +521,17 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="157"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="151"/>
         <source>Version Seperator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="191"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="185"/>
         <source>Remove %1</source>
         <translation>Rimuovi %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="192"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="186"/>
         <source>Do you want to permanently remove %1?</source>
         <translation>Vuoi rimuovere definitivamente %1?</translation>
     </message>
@@ -549,79 +563,74 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>%1 non è in linea</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="169"/>
         <source>File transfer file name</source>
         <extracomment>Description of the text displaying the filename of a file transfer, used by accessibility tech like screen readres</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="195"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="185"/>
         <source>File transfer progress</source>
         <extracomment>Description of progress bar displaying the file transfer progress, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="210"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="200"/>
         <source>File transfer status</source>
         <extracomment>Description of label displaying the current status of a file transfer, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="225"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="215"/>
         <source>Download</source>
         <extracomment>Label for file transfer &apos;Download&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="227"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="217"/>
         <source>Download file</source>
         <extracomment>Description of what the file transfer &apos;Download&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="244"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="234"/>
         <source>Cancel or reject</source>
         <extracomment>Label for file transfer &apos;Cancel&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="246"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="236"/>
         <source>Cancels or rejects a file transfer</source>
         <extracomment>Description of what the file transfer &apos;Cancel&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="310"/>
         <source>Copy ID</source>
         <extracomment>Text for context menu command to copy a ricochet contact id to clipboard</extracomment>
-        <translation>Copia ID</translation>
+        <translation type="vanished">Copia ID</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="281"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="312"/>
         <source>Copy Link</source>
         <extracomment>Text for context menu command to copy a url to the clipboard</extracomment>
-        <translation>Copia link</translation>
+        <translation type="vanished">Copia link</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="287"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="318"/>
         <source>Open with Browser</source>
         <extracomment>Text for context menu command to open a url in a web browser</extracomment>
-        <translation>Apri nel il browser</translation>
+        <translation type="vanished">Apri nel il browser</translation>
     </message>
     <message>
         <source>Add as Contact</source>
         <translation type="vanished">Aggiungi ai tuoi contatti</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="335"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="262"/>
         <source>Copy Message</source>
         <extracomment>Text for context menu command to copy an entire message to clipboard</extracomment>
         <translation>Copia messaggio</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="343"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="270"/>
         <source>Copy Selection</source>
         <extracomment>Text for context menu command to copy selected text to clipboard</extracomment>
         <translation>Copia selezione</translation>
@@ -705,38 +714,28 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>OpenBrowserDialog</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="41"/>
         <source>&lt;b&gt;Warning!&lt;/b&gt; Opening links with your default browser will harm your security and anonymity.&lt;br&gt;&lt;br&gt;You can &lt;a href=&apos;.&apos;&gt;copy to the clipboard&lt;/a&gt; instead.</source>
         <extracomment>Label displayed when user clicks on a link</extracomment>
-        <translation>&lt;b&gt;Attenzione!&lt;/b&gt; Aprire un link nel browser di default metterà a repentaglio la tua sicurezza e anonimia.&lt;br&gt;&lt;br&gt;Puoi invece &lt;a href=&apos;.&apos;&gt;copiarlo negli appunti&lt;/a&gt;.</translation>
+        <translation type="vanished">&lt;b&gt;Attenzione!&lt;/b&gt; Aprire un link nel browser di default metterà a repentaglio la tua sicurezza e anonimia.&lt;br&gt;&lt;br&gt;Puoi invece &lt;a href=&apos;.&apos;&gt;copiarlo negli appunti&lt;/a&gt;.</translation>
     </message>
     <message>
         <source>Don&apos;t ask again for links from %1</source>
         <translation type="vanished">Non chiedere più per i link inviati da %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="50"/>
-        <source>Warning</source>
-        <extracomment>Name of warning label used with accessibility tech such as screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="65"/>
         <source>Don&apos;t ask again for any links (not recommended!)</source>
         <extracomment>Checkbox option text for when user clicks on a link</extracomment>
-        <translation>Non chiedere più per ogni link (scelta non consigliata)</translation>
+        <translation type="vanished">Non chiedere più per ogni link (scelta non consigliata)</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="73"/>
         <source>Open Browser</source>
         <extracomment>Label on button to open link in a web browser</extracomment>
-        <translation>Apri browser</translation>
+        <translation type="vanished">Apri browser</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="84"/>
         <source>Cancel</source>
         <extracomment>Label on cancel button</extracomment>
-        <translation>Annulla</translation>
+        <translation type="vanished">Annulla</translation>
     </message>
 </context>
 <context>
@@ -878,144 +877,144 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>Questo computer necessita di un proxy per accedere a internet?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="69"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="70"/>
         <source>Proxy type:</source>
         <translation>Tipo di proxy:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="74"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="75"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="77"/>
         <source>None</source>
         <translation>Nessuno</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="92"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="93"/>
         <source>If you need a proxy to access the internet, select one from this list.</source>
         <extracomment>Description used by accessibility tech, such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="97"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="98"/>
         <source>Address:</source>
         <extracomment>Label indicating the textbox to place a proxy IP or URL</extracomment>
         <translation>Indirizzo:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="111"/>
         <source>IP address or hostname</source>
         <extracomment>Placeholder text of text box expecting an IP or URL for proxy</extracomment>
         <translation>Indirizzo IP o nome host</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="115"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="116"/>
         <source>Enter the IP address or hostname of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the IP textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="119"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="120"/>
         <source>Port:</source>
         <extracomment>Label indicating the textbox to place a proxy port</extracomment>
         <translation>Porta:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="130"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="131"/>
         <source>Port</source>
         <extracomment>Name of the port label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="132"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="133"/>
         <source>Enter the port of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the Port textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="138"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="139"/>
         <source>Username:</source>
         <extracomment>Label indicating the textbox to place the proxy username</extracomment>
         <translation>Nome utente:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="152"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="173"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="153"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="174"/>
         <source>Optional</source>
         <extracomment>Textbox placeholder text indicating the field is not required</extracomment>
         <translation>Facoltativo</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="156"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="157"/>
         <source>Username</source>
         <extracomment>Name of the username label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="158"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="159"/>
         <source>If required, enter the username for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Username textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="162"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="163"/>
         <source>Password:</source>
         <extracomment>Label indicating the textbox to place the proxy password</extracomment>
         <translation>Password:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="177"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="178"/>
         <source>Password</source>
         <extracomment>Name of the password label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="180"/>
         <source>If required, enter the password for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Password textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="190"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="191"/>
         <source>Does this computer&apos;s Internet connection go through a firewall that only allows connections to certain ports?</source>
         <extracomment>Description for the purpose of the Allowed Ports textbox</extracomment>
         <translation>La connessione ad Internet di questo computer passa attraverso un firewall che consente la connessione solo su determinate porte?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="211"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="212"/>
         <source>Allowed ports:</source>
         <extracomment>Label indicating the textbox to place the allowed ports</extracomment>
         <translation>Porte consentite:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="220"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="221"/>
         <source>Example: 80,443</source>
         <extracomment>Textbox showing an example entry for the firewall allowed ports entry</extracomment>
         <translation>Esempio: 80,443</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="224"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="225"/>
         <source>Allowed ports</source>
         <extracomment>Name of the allowed ports label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="236"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="237"/>
         <source>If this computer&apos;s Internet connection is censored, you will need to obtain and use bridge relays.</source>
         <translation>Se la connessione a Internet di questo computer è censurata dovrai ottenere ed usare dei bridge relay</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="251"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="262"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="252"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="263"/>
         <source>Enter one or more bridge relays (one per line):</source>
         <translation>Aggiungi uno o più bridge relay (uno per linea):</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="273"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="274"/>
         <source>Back</source>
         <extracomment>Button label for going back to previous screen</extracomment>
         <translation>Indietro</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="284"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="285"/>
         <source>Connect</source>
         <extracomment>Button label for connecting to tor</extracomment>
         <translation>Connetti</translation>
@@ -1192,51 +1191,65 @@ Name of the button for launching the preferences window for accessibility tech l
     </message>
     <message>
         <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="114"/>
+        <source>Accepted</source>
+        <translation type="unfinished">Accettato</translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="115"/>
         <source>Rejected</source>
         <translation type="unfinished">Rifiutato</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="120"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
         <source>Cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
         <source>Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
         <source>Unkown Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
         <source>Bad File Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
         <source>Network Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="126"/>
         <source>File System Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="127"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="128"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="220"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="223"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="395"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="285"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="289"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="295"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="309"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="350"/>
+        <source>me</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="436"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/tego_ui/translation/ricochet_ja.ts
+++ b/src/tego_ui/translation/ricochet_ja.ts
@@ -21,29 +21,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="36"/>
-        <source>Ricochet Refresh web home page</source>
-        <extracomment>provides context for the URL for accessibility tech like screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="59"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="32"/>
         <source>The license of Ricochet Refresh and its dependencies</source>
-        <extracomment>summary of a block of text for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="60"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="33"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="65"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="37"/>
         <source>About</source>
         <translation type="unfinished">情報</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="39"/>
         <source>About page, contains license and version information</source>
         <extracomment>summary of the window&apos;s contents for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -105,37 +98,53 @@
 <context>
     <name>ContactActions</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="49"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <source>Could not successfully export conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="65"/>
         <source>Open Window</source>
         <extracomment>Context menu command to open the chat screen in a separate window</extracomment>
         <translation>ウィンドウを開く</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="70"/>
         <source>Details...</source>
         <extracomment>Context menu command to open a window showing the selected contact&apos;s details</extracomment>
         <translation>詳細</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="56"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="75"/>
         <source>Rename</source>
         <extracomment>Context menu command to rename the selected contact</extracomment>
         <translation>名前を変更する</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="61"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="80"/>
         <source>Send File...</source>
         <extracomment>Context menu command to initiate a file transfer, opens a system file dialog</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="85"/>
+        <source>Export Conversation</source>
+        <extracomment>Context menu command to initiate a chat log export, opens a system file dialog to export to</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="91"/>
         <source>Remove</source>
         <extracomment>Context menu command to remove a contact from the contact list</extracomment>
         <translation>削除する</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="74"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="98"/>
         <source>Contact options</source>
         <extracomment>Description of the items in the context menu for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -151,30 +160,36 @@
     </message>
     <message>
         <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="45"/>
+        <source>This ID is invalid</source>
+        <extracomment>Error message showed when the id doesn&apos;t comply with spec https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
         <source>You can&apos;t add yourself as a contact</source>
         <extracomment>Error message showed when user attempts to add themselves as a contact in their contact list</extracomment>
         <translation>自分自身をコンタクトに追加することはできません</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="55"/>
         <source>Enter an ID starting with &lt;b&gt;ricochet:&lt;/b&gt;</source>
         <extracomment>Error message showed when the provided ricochet id is invalid</extracomment>
         <translation>&lt;b&gt;リコシェイ&lt;/b&gt; から始まるID を入力してください</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="88"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="97"/>
         <source>Copied to clipboard</source>
         <extracomment>Message displayed when text is copied to the user&apos;s clipboard</extracomment>
         <translation>クリップボードにコピーしました</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="103"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="112"/>
         <source>Copy</source>
         <extracomment>Text displayed on a button used to copy somethign to the user&apos;s clipboard</extracomment>
         <translation>コピー</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="119"/>
         <source>Copies the ricochet id to the clipboard</source>
         <extracomment>Text description of ricochet id copy button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -397,20 +412,19 @@
         <translation>一つのウィンドウで会話する</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Open links in default browser without prompting</source>
         <extracomment>Text description of an option to open URLs in default web browser when clicked</extracomment>
-        <translation>ブラウザでウェブリンクを開く際には都度通知せず開く</translation>
+        <translation type="vanished">ブラウザでウェブリンクを開く際には都度通知せず開く</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="44"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Play audio notifications</source>
         <extracomment>Text description of an option to play audio notifications when contacts log in, log out, and send messages</extracomment>
         <translation>通知音を鳴らす</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="61"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="77"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="62"/>
         <source>Volume</source>
         <extracomment>Label for a slider used to adjust audio notification volume
 ----------
@@ -418,8 +432,8 @@ Name of the slider used to adjust audio notification volume for accessibility te
         <translation>音量</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="91"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="129"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="114"/>
         <source>Language</source>
         <extracomment>Label for combobox where users can specify the UI language
 ----------
@@ -427,12 +441,12 @@ Name of the combobox used to select UI langauge for accessibility tech like scre
         <translation type="unfinished">言語</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="117"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="102"/>
         <source>Restart Ricochet to apply changes</source>
         <translation type="unfinished">変更を反映するためリコシェイを再起動する</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="131"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="116"/>
         <source>What language ricochet will use</source>
         <extracomment>Description of what the language combox is for for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -507,17 +521,17 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="157"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="151"/>
         <source>Version Seperator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="191"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="185"/>
         <source>Remove %1</source>
         <translation>%1を削除する</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="192"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="186"/>
         <source>Do you want to permanently remove %1?</source>
         <translation>%1を永久に削除しますか？</translation>
     </message>
@@ -549,79 +563,74 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>%1はオフラインです</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="169"/>
         <source>File transfer file name</source>
         <extracomment>Description of the text displaying the filename of a file transfer, used by accessibility tech like screen readres</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="195"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="185"/>
         <source>File transfer progress</source>
         <extracomment>Description of progress bar displaying the file transfer progress, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="210"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="200"/>
         <source>File transfer status</source>
         <extracomment>Description of label displaying the current status of a file transfer, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="225"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="215"/>
         <source>Download</source>
         <extracomment>Label for file transfer &apos;Download&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="227"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="217"/>
         <source>Download file</source>
         <extracomment>Description of what the file transfer &apos;Download&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="244"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="234"/>
         <source>Cancel or reject</source>
         <extracomment>Label for file transfer &apos;Cancel&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="246"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="236"/>
         <source>Cancels or rejects a file transfer</source>
         <extracomment>Description of what the file transfer &apos;Cancel&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="310"/>
         <source>Copy ID</source>
         <extracomment>Text for context menu command to copy a ricochet contact id to clipboard</extracomment>
-        <translation>IDをコピーする</translation>
+        <translation type="vanished">IDをコピーする</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="281"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="312"/>
         <source>Copy Link</source>
         <extracomment>Text for context menu command to copy a url to the clipboard</extracomment>
-        <translation>リンクをコピーする</translation>
+        <translation type="vanished">リンクをコピーする</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="287"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="318"/>
         <source>Open with Browser</source>
         <extracomment>Text for context menu command to open a url in a web browser</extracomment>
-        <translation>ブラウザで開く</translation>
+        <translation type="vanished">ブラウザで開く</translation>
     </message>
     <message>
         <source>Add as Contact</source>
         <translation type="vanished">コンタクトに追加する</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="335"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="262"/>
         <source>Copy Message</source>
         <extracomment>Text for context menu command to copy an entire message to clipboard</extracomment>
         <translation>メッセージをコピーする</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="343"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="270"/>
         <source>Copy Selection</source>
         <extracomment>Text for context menu command to copy selected text to clipboard</extracomment>
         <translation>選択範囲をコピーする</translation>
@@ -705,38 +714,28 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>OpenBrowserDialog</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="41"/>
         <source>&lt;b&gt;Warning!&lt;/b&gt; Opening links with your default browser will harm your security and anonymity.&lt;br&gt;&lt;br&gt;You can &lt;a href=&apos;.&apos;&gt;copy to the clipboard&lt;/a&gt; instead.</source>
         <extracomment>Label displayed when user clicks on a link</extracomment>
-        <translation>&lt;b&gt; 警告！&lt;b/&gt; このリンクを既定のブラウザで開くとあなたのセキュリティと匿名性に害を及ぼす可能性があります。&lt;br&gt;&lt;br&gt; 代わりに&lt;a href=&apos;,&apos;&gt; クリップボードにコピーする&lt;/a&gt; こともできます。</translation>
+        <translation type="vanished">&lt;b&gt; 警告！&lt;b/&gt; このリンクを既定のブラウザで開くとあなたのセキュリティと匿名性に害を及ぼす可能性があります。&lt;br&gt;&lt;br&gt; 代わりに&lt;a href=&apos;,&apos;&gt; クリップボードにコピーする&lt;/a&gt; こともできます。</translation>
     </message>
     <message>
         <source>Don&apos;t ask again for links from %1</source>
         <translation type="vanished">%1からのリンクはいつも許可する</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="50"/>
-        <source>Warning</source>
-        <extracomment>Name of warning label used with accessibility tech such as screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="65"/>
         <source>Don&apos;t ask again for any links (not recommended!)</source>
         <extracomment>Checkbox option text for when user clicks on a link</extracomment>
-        <translation>%1からのすべてのリンクを再確認しない(非推奨)</translation>
+        <translation type="vanished">%1からのすべてのリンクを再確認しない(非推奨)</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="73"/>
         <source>Open Browser</source>
         <extracomment>Label on button to open link in a web browser</extracomment>
-        <translation>ブラウザを開く</translation>
+        <translation type="vanished">ブラウザを開く</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="84"/>
         <source>Cancel</source>
         <extracomment>Label on cancel button</extracomment>
-        <translation>取り消す</translation>
+        <translation type="vanished">取り消す</translation>
     </message>
 </context>
 <context>
@@ -878,144 +877,144 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>このコンピュータはインターネットにアクセスするのにプロキシが必要ですか？</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="69"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="70"/>
         <source>Proxy type:</source>
         <translation>プロキシの種類</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="74"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="75"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="77"/>
         <source>None</source>
         <translation>無い</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="92"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="93"/>
         <source>If you need a proxy to access the internet, select one from this list.</source>
         <extracomment>Description used by accessibility tech, such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="97"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="98"/>
         <source>Address:</source>
         <extracomment>Label indicating the textbox to place a proxy IP or URL</extracomment>
         <translation>アドレス</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="111"/>
         <source>IP address or hostname</source>
         <extracomment>Placeholder text of text box expecting an IP or URL for proxy</extracomment>
         <translation>IPアドレスかホストネーム</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="115"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="116"/>
         <source>Enter the IP address or hostname of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the IP textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="119"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="120"/>
         <source>Port:</source>
         <extracomment>Label indicating the textbox to place a proxy port</extracomment>
         <translation>ポート</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="130"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="131"/>
         <source>Port</source>
         <extracomment>Name of the port label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="132"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="133"/>
         <source>Enter the port of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the Port textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="138"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="139"/>
         <source>Username:</source>
         <extracomment>Label indicating the textbox to place the proxy username</extracomment>
         <translation>ユーザーネーム</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="152"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="173"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="153"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="174"/>
         <source>Optional</source>
         <extracomment>Textbox placeholder text indicating the field is not required</extracomment>
         <translation>必須では無い</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="156"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="157"/>
         <source>Username</source>
         <extracomment>Name of the username label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="158"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="159"/>
         <source>If required, enter the username for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Username textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="162"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="163"/>
         <source>Password:</source>
         <extracomment>Label indicating the textbox to place the proxy password</extracomment>
         <translation>パスワード</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="177"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="178"/>
         <source>Password</source>
         <extracomment>Name of the password label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="180"/>
         <source>If required, enter the password for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Password textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="190"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="191"/>
         <source>Does this computer&apos;s Internet connection go through a firewall that only allows connections to certain ports?</source>
         <extracomment>Description for the purpose of the Allowed Ports textbox</extracomment>
         <translation>このコンピュータは特定のポートの身を許可するファイアウォールを経由しますか？</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="211"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="212"/>
         <source>Allowed ports:</source>
         <extracomment>Label indicating the textbox to place the allowed ports</extracomment>
         <translation>許可されたポート</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="220"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="221"/>
         <source>Example: 80,443</source>
         <extracomment>Textbox showing an example entry for the firewall allowed ports entry</extracomment>
         <translation>例えば：80&#xa0;、443</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="224"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="225"/>
         <source>Allowed ports</source>
         <extracomment>Name of the allowed ports label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="236"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="237"/>
         <source>If this computer&apos;s Internet connection is censored, you will need to obtain and use bridge relays.</source>
         <translation>このコンピュータのインターネット接続が検知された場合、ブリッジリレーを手に入れて利用する必要があります</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="251"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="262"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="252"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="263"/>
         <source>Enter one or more bridge relays (one per line):</source>
         <translation>1つもしくはそれ以上のブリッジリレーを入力してください(１ラインにつき１つ)：</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="273"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="274"/>
         <source>Back</source>
         <extracomment>Button label for going back to previous screen</extracomment>
         <translation>戻る</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="284"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="285"/>
         <source>Connect</source>
         <extracomment>Button label for connecting to tor</extracomment>
         <translation>接続する</translation>
@@ -1192,51 +1191,65 @@ Name of the button for launching the preferences window for accessibility tech l
     </message>
     <message>
         <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="114"/>
+        <source>Accepted</source>
+        <translation type="unfinished">受諾されました</translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="115"/>
         <source>Rejected</source>
         <translation type="unfinished">拒否されました</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="120"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
         <source>Cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
         <source>Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
         <source>Unkown Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
         <source>Bad File Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
         <source>Network Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="126"/>
         <source>File System Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="127"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="128"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="220"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="223"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="395"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="285"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="289"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="295"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="309"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="350"/>
+        <source>me</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="436"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/tego_ui/translation/ricochet_nb.ts
+++ b/src/tego_ui/translation/ricochet_nb.ts
@@ -21,29 +21,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="36"/>
-        <source>Ricochet Refresh web home page</source>
-        <extracomment>provides context for the URL for accessibility tech like screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="59"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="32"/>
         <source>The license of Ricochet Refresh and its dependencies</source>
-        <extracomment>summary of a block of text for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="60"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="33"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="65"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="37"/>
         <source>About</source>
         <translation type="unfinished">Om</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="39"/>
         <source>About page, contains license and version information</source>
         <extracomment>summary of the window&apos;s contents for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -105,37 +98,53 @@
 <context>
     <name>ContactActions</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="49"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <source>Could not successfully export conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="65"/>
         <source>Open Window</source>
         <extracomment>Context menu command to open the chat screen in a separate window</extracomment>
         <translation>Åpne vindu</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="70"/>
         <source>Details...</source>
         <extracomment>Context menu command to open a window showing the selected contact&apos;s details</extracomment>
         <translation>Detaljer...</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="56"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="75"/>
         <source>Rename</source>
         <extracomment>Context menu command to rename the selected contact</extracomment>
         <translation>Endre navn</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="61"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="80"/>
         <source>Send File...</source>
         <extracomment>Context menu command to initiate a file transfer, opens a system file dialog</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="85"/>
+        <source>Export Conversation</source>
+        <extracomment>Context menu command to initiate a chat log export, opens a system file dialog to export to</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="91"/>
         <source>Remove</source>
         <extracomment>Context menu command to remove a contact from the contact list</extracomment>
         <translation>Fjern</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="74"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="98"/>
         <source>Contact options</source>
         <extracomment>Description of the items in the context menu for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -151,30 +160,36 @@
     </message>
     <message>
         <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="45"/>
+        <source>This ID is invalid</source>
+        <extracomment>Error message showed when the id doesn&apos;t comply with spec https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
         <source>You can&apos;t add yourself as a contact</source>
         <extracomment>Error message showed when user attempts to add themselves as a contact in their contact list</extracomment>
         <translation>Du kan ikke legge til deg selv som en kontakt</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="55"/>
         <source>Enter an ID starting with &lt;b&gt;ricochet:&lt;/b&gt;</source>
         <extracomment>Error message showed when the provided ricochet id is invalid</extracomment>
         <translation>Skriv inn en ID som starter med &lt;b&gt;ricochet:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="88"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="97"/>
         <source>Copied to clipboard</source>
         <extracomment>Message displayed when text is copied to the user&apos;s clipboard</extracomment>
         <translation>Kopiert til utklippstavlen</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="103"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="112"/>
         <source>Copy</source>
         <extracomment>Text displayed on a button used to copy somethign to the user&apos;s clipboard</extracomment>
         <translation>Kopier</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="119"/>
         <source>Copies the ricochet id to the clipboard</source>
         <extracomment>Text description of ricochet id copy button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -397,20 +412,19 @@
         <translation>Bruk ètt vindu for samtaler</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Open links in default browser without prompting</source>
         <extracomment>Text description of an option to open URLs in default web browser when clicked</extracomment>
-        <translation>Åpne lenker i standardnettleser uten å spørre</translation>
+        <translation type="vanished">Åpne lenker i standardnettleser uten å spørre</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="44"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Play audio notifications</source>
         <extracomment>Text description of an option to play audio notifications when contacts log in, log out, and send messages</extracomment>
         <translation>Spill av lydvarsler</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="61"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="77"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="62"/>
         <source>Volume</source>
         <extracomment>Label for a slider used to adjust audio notification volume
 ----------
@@ -418,8 +432,8 @@ Name of the slider used to adjust audio notification volume for accessibility te
         <translation>Volum</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="91"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="129"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="114"/>
         <source>Language</source>
         <extracomment>Label for combobox where users can specify the UI language
 ----------
@@ -427,12 +441,12 @@ Name of the combobox used to select UI langauge for accessibility tech like scre
         <translation type="unfinished">Språk</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="117"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="102"/>
         <source>Restart Ricochet to apply changes</source>
         <translation type="unfinished">Ta en omstart av Ricochet for å bruke endringene</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="131"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="116"/>
         <source>What language ricochet will use</source>
         <extracomment>Description of what the language combox is for for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -507,17 +521,17 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="157"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="151"/>
         <source>Version Seperator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="191"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="185"/>
         <source>Remove %1</source>
         <translation>Fjern %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="192"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="186"/>
         <source>Do you want to permanently remove %1?</source>
         <translation>Ønsker du å slette %1 for alltid?</translation>
     </message>
@@ -549,79 +563,74 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>%1 er frakoblet</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="169"/>
         <source>File transfer file name</source>
         <extracomment>Description of the text displaying the filename of a file transfer, used by accessibility tech like screen readres</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="195"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="185"/>
         <source>File transfer progress</source>
         <extracomment>Description of progress bar displaying the file transfer progress, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="210"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="200"/>
         <source>File transfer status</source>
         <extracomment>Description of label displaying the current status of a file transfer, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="225"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="215"/>
         <source>Download</source>
         <extracomment>Label for file transfer &apos;Download&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="227"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="217"/>
         <source>Download file</source>
         <extracomment>Description of what the file transfer &apos;Download&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="244"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="234"/>
         <source>Cancel or reject</source>
         <extracomment>Label for file transfer &apos;Cancel&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="246"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="236"/>
         <source>Cancels or rejects a file transfer</source>
         <extracomment>Description of what the file transfer &apos;Cancel&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="310"/>
         <source>Copy ID</source>
         <extracomment>Text for context menu command to copy a ricochet contact id to clipboard</extracomment>
-        <translation>Kopier ID</translation>
+        <translation type="vanished">Kopier ID</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="281"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="312"/>
         <source>Copy Link</source>
         <extracomment>Text for context menu command to copy a url to the clipboard</extracomment>
-        <translation>Kopier lenke</translation>
+        <translation type="vanished">Kopier lenke</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="287"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="318"/>
         <source>Open with Browser</source>
         <extracomment>Text for context menu command to open a url in a web browser</extracomment>
-        <translation>Åpne i nettleser</translation>
+        <translation type="vanished">Åpne i nettleser</translation>
     </message>
     <message>
         <source>Add as Contact</source>
         <translation type="vanished">Legg til som kontakt</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="335"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="262"/>
         <source>Copy Message</source>
         <extracomment>Text for context menu command to copy an entire message to clipboard</extracomment>
         <translation>Kopier melding</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="343"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="270"/>
         <source>Copy Selection</source>
         <extracomment>Text for context menu command to copy selected text to clipboard</extracomment>
         <translation>Kopier utvalg</translation>
@@ -705,38 +714,28 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>OpenBrowserDialog</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="41"/>
         <source>&lt;b&gt;Warning!&lt;/b&gt; Opening links with your default browser will harm your security and anonymity.&lt;br&gt;&lt;br&gt;You can &lt;a href=&apos;.&apos;&gt;copy to the clipboard&lt;/a&gt; instead.</source>
         <extracomment>Label displayed when user clicks on a link</extracomment>
-        <translation>&lt;b&gt;Advarsel!&lt;/b&gt; Åpning av lenker i din standardnettleser vil svekke sikkerheten og minske anonymiteten din.&lt;br&gt;&lt;br&gt;Du kan &lt;a href=&apos;.&apos;&gt;kopiere til utklippstavlen&lt;/a&gt; i stedet for.</translation>
+        <translation type="vanished">&lt;b&gt;Advarsel!&lt;/b&gt; Åpning av lenker i din standardnettleser vil svekke sikkerheten og minske anonymiteten din.&lt;br&gt;&lt;br&gt;Du kan &lt;a href=&apos;.&apos;&gt;kopiere til utklippstavlen&lt;/a&gt; i stedet for.</translation>
     </message>
     <message>
         <source>Don&apos;t ask again for links from %1</source>
         <translation type="vanished">Ikke spør igjen for lenker fra %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="50"/>
-        <source>Warning</source>
-        <extracomment>Name of warning label used with accessibility tech such as screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="65"/>
         <source>Don&apos;t ask again for any links (not recommended!)</source>
         <extracomment>Checkbox option text for when user clicks on a link</extracomment>
-        <translation>Ikke spør igjen for noen lenker som helst (ikke anbefalt!)</translation>
+        <translation type="vanished">Ikke spør igjen for noen lenker som helst (ikke anbefalt!)</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="73"/>
         <source>Open Browser</source>
         <extracomment>Label on button to open link in a web browser</extracomment>
-        <translation>Åpne nettleser</translation>
+        <translation type="vanished">Åpne nettleser</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="84"/>
         <source>Cancel</source>
         <extracomment>Label on cancel button</extracomment>
-        <translation>Avbryt</translation>
+        <translation type="vanished">Avbryt</translation>
     </message>
 </context>
 <context>
@@ -878,144 +877,144 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>Trenger denne datamaskinen proxy for å få tilgang til Internett?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="69"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="70"/>
         <source>Proxy type:</source>
         <translation>Proxytype:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="74"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="75"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="77"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="92"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="93"/>
         <source>If you need a proxy to access the internet, select one from this list.</source>
         <extracomment>Description used by accessibility tech, such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="97"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="98"/>
         <source>Address:</source>
         <extracomment>Label indicating the textbox to place a proxy IP or URL</extracomment>
         <translation>Adresse:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="111"/>
         <source>IP address or hostname</source>
         <extracomment>Placeholder text of text box expecting an IP or URL for proxy</extracomment>
         <translation>IP-adresse eller vertsnavn</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="115"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="116"/>
         <source>Enter the IP address or hostname of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the IP textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="119"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="120"/>
         <source>Port:</source>
         <extracomment>Label indicating the textbox to place a proxy port</extracomment>
         <translation>Port:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="130"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="131"/>
         <source>Port</source>
         <extracomment>Name of the port label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="132"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="133"/>
         <source>Enter the port of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the Port textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="138"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="139"/>
         <source>Username:</source>
         <extracomment>Label indicating the textbox to place the proxy username</extracomment>
         <translation>Brukernavn:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="152"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="173"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="153"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="174"/>
         <source>Optional</source>
         <extracomment>Textbox placeholder text indicating the field is not required</extracomment>
         <translation>Valgfri</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="156"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="157"/>
         <source>Username</source>
         <extracomment>Name of the username label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="158"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="159"/>
         <source>If required, enter the username for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Username textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="162"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="163"/>
         <source>Password:</source>
         <extracomment>Label indicating the textbox to place the proxy password</extracomment>
         <translation>Passord:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="177"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="178"/>
         <source>Password</source>
         <extracomment>Name of the password label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="180"/>
         <source>If required, enter the password for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Password textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="190"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="191"/>
         <source>Does this computer&apos;s Internet connection go through a firewall that only allows connections to certain ports?</source>
         <extracomment>Description for the purpose of the Allowed Ports textbox</extracomment>
         <translation>Går denne datamaskinens internettforbindelse gjennom en brannmur som kun tillater forbindelser til bestemte porter?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="211"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="212"/>
         <source>Allowed ports:</source>
         <extracomment>Label indicating the textbox to place the allowed ports</extracomment>
         <translation>Tillatte porter:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="220"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="221"/>
         <source>Example: 80,443</source>
         <extracomment>Textbox showing an example entry for the firewall allowed ports entry</extracomment>
         <translation>Eksempel: 80,443</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="224"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="225"/>
         <source>Allowed ports</source>
         <extracomment>Name of the allowed ports label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="236"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="237"/>
         <source>If this computer&apos;s Internet connection is censored, you will need to obtain and use bridge relays.</source>
         <translation>Hvis denne datamaskinens internettforbindelse er sensurert må du få tak i og bruke broreléer.</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="251"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="262"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="252"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="263"/>
         <source>Enter one or more bridge relays (one per line):</source>
         <translation>Skriv inn et eller flere broreléer (et relé per linje):</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="273"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="274"/>
         <source>Back</source>
         <extracomment>Button label for going back to previous screen</extracomment>
         <translation>Tilbake</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="284"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="285"/>
         <source>Connect</source>
         <extracomment>Button label for connecting to tor</extracomment>
         <translation>Koble til</translation>
@@ -1192,51 +1191,65 @@ Name of the button for launching the preferences window for accessibility tech l
     </message>
     <message>
         <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="114"/>
+        <source>Accepted</source>
+        <translation type="unfinished">Godtatt</translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="115"/>
         <source>Rejected</source>
         <translation type="unfinished">Avvist</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="120"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
         <source>Cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
         <source>Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
         <source>Unkown Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
         <source>Bad File Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
         <source>Network Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="126"/>
         <source>File System Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="127"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="128"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="220"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="223"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="395"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="285"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="289"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="295"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="309"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="350"/>
+        <source>me</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="436"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/tego_ui/translation/ricochet_nl_NL.ts
+++ b/src/tego_ui/translation/ricochet_nl_NL.ts
@@ -21,29 +21,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="36"/>
-        <source>Ricochet Refresh web home page</source>
-        <extracomment>provides context for the URL for accessibility tech like screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="59"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="32"/>
         <source>The license of Ricochet Refresh and its dependencies</source>
-        <extracomment>summary of a block of text for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="60"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="33"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="65"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="37"/>
         <source>About</source>
         <translation type="unfinished">Over</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="39"/>
         <source>About page, contains license and version information</source>
         <extracomment>summary of the window&apos;s contents for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -105,37 +98,53 @@
 <context>
     <name>ContactActions</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="49"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <source>Could not successfully export conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="65"/>
         <source>Open Window</source>
         <extracomment>Context menu command to open the chat screen in a separate window</extracomment>
         <translation>Open venster</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="70"/>
         <source>Details...</source>
         <extracomment>Context menu command to open a window showing the selected contact&apos;s details</extracomment>
         <translation>Details...</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="56"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="75"/>
         <source>Rename</source>
         <extracomment>Context menu command to rename the selected contact</extracomment>
         <translation>Hernoemen</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="61"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="80"/>
         <source>Send File...</source>
         <extracomment>Context menu command to initiate a file transfer, opens a system file dialog</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="85"/>
+        <source>Export Conversation</source>
+        <extracomment>Context menu command to initiate a chat log export, opens a system file dialog to export to</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="91"/>
         <source>Remove</source>
         <extracomment>Context menu command to remove a contact from the contact list</extracomment>
         <translation>Verwijderen</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="74"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="98"/>
         <source>Contact options</source>
         <extracomment>Description of the items in the context menu for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -151,30 +160,36 @@
     </message>
     <message>
         <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="45"/>
+        <source>This ID is invalid</source>
+        <extracomment>Error message showed when the id doesn&apos;t comply with spec https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
         <source>You can&apos;t add yourself as a contact</source>
         <extracomment>Error message showed when user attempts to add themselves as a contact in their contact list</extracomment>
         <translation>Je kunt jezelf niet als contact toevoegen</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="55"/>
         <source>Enter an ID starting with &lt;b&gt;ricochet:&lt;/b&gt;</source>
         <extracomment>Error message showed when the provided ricochet id is invalid</extracomment>
         <translation>Geef een ID op dat begint met &lt;b&gt;ricochet:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="88"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="97"/>
         <source>Copied to clipboard</source>
         <extracomment>Message displayed when text is copied to the user&apos;s clipboard</extracomment>
         <translation>Gekopieerd naar klembord</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="103"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="112"/>
         <source>Copy</source>
         <extracomment>Text displayed on a button used to copy somethign to the user&apos;s clipboard</extracomment>
         <translation>Kopieer</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="119"/>
         <source>Copies the ricochet id to the clipboard</source>
         <extracomment>Text description of ricochet id copy button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -397,20 +412,19 @@
         <translation>Gebruik een enkel venster voor gesprekken</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Open links in default browser without prompting</source>
         <extracomment>Text description of an option to open URLs in default web browser when clicked</extracomment>
-        <translation>Open links in standaardbrowser zonder te vragen </translation>
+        <translation type="vanished">Open links in standaardbrowser zonder te vragen </translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="44"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Play audio notifications</source>
         <extracomment>Text description of an option to play audio notifications when contacts log in, log out, and send messages</extracomment>
         <translation>Afspelen audio meldingen</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="61"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="77"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="62"/>
         <source>Volume</source>
         <extracomment>Label for a slider used to adjust audio notification volume
 ----------
@@ -418,8 +432,8 @@ Name of the slider used to adjust audio notification volume for accessibility te
         <translation>Volume</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="91"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="129"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="114"/>
         <source>Language</source>
         <extracomment>Label for combobox where users can specify the UI language
 ----------
@@ -427,12 +441,12 @@ Name of the combobox used to select UI langauge for accessibility tech like scre
         <translation type="unfinished">Taal</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="117"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="102"/>
         <source>Restart Ricochet to apply changes</source>
         <translation type="unfinished">Herstart Ricochet om wijzigingen door te voeren</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="131"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="116"/>
         <source>What language ricochet will use</source>
         <extracomment>Description of what the language combox is for for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -507,17 +521,17 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="157"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="151"/>
         <source>Version Seperator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="191"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="185"/>
         <source>Remove %1</source>
         <translation>Verwijder %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="192"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="186"/>
         <source>Do you want to permanently remove %1?</source>
         <translation>Wil je %1 permanent verwijderen?</translation>
     </message>
@@ -549,79 +563,74 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>%1 is offline</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="169"/>
         <source>File transfer file name</source>
         <extracomment>Description of the text displaying the filename of a file transfer, used by accessibility tech like screen readres</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="195"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="185"/>
         <source>File transfer progress</source>
         <extracomment>Description of progress bar displaying the file transfer progress, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="210"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="200"/>
         <source>File transfer status</source>
         <extracomment>Description of label displaying the current status of a file transfer, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="225"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="215"/>
         <source>Download</source>
         <extracomment>Label for file transfer &apos;Download&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="227"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="217"/>
         <source>Download file</source>
         <extracomment>Description of what the file transfer &apos;Download&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="244"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="234"/>
         <source>Cancel or reject</source>
         <extracomment>Label for file transfer &apos;Cancel&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="246"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="236"/>
         <source>Cancels or rejects a file transfer</source>
         <extracomment>Description of what the file transfer &apos;Cancel&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="310"/>
         <source>Copy ID</source>
         <extracomment>Text for context menu command to copy a ricochet contact id to clipboard</extracomment>
-        <translation>Kopieer ID</translation>
+        <translation type="vanished">Kopieer ID</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="281"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="312"/>
         <source>Copy Link</source>
         <extracomment>Text for context menu command to copy a url to the clipboard</extracomment>
-        <translation>Kopieer link</translation>
+        <translation type="vanished">Kopieer link</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="287"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="318"/>
         <source>Open with Browser</source>
         <extracomment>Text for context menu command to open a url in a web browser</extracomment>
-        <translation>Open met browser</translation>
+        <translation type="vanished">Open met browser</translation>
     </message>
     <message>
         <source>Add as Contact</source>
         <translation type="vanished">Toevoegen als contact</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="335"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="262"/>
         <source>Copy Message</source>
         <extracomment>Text for context menu command to copy an entire message to clipboard</extracomment>
         <translation>Kopiëren bericht</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="343"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="270"/>
         <source>Copy Selection</source>
         <extracomment>Text for context menu command to copy selected text to clipboard</extracomment>
         <translation>Kopiëren selectie</translation>
@@ -705,38 +714,28 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>OpenBrowserDialog</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="41"/>
         <source>&lt;b&gt;Warning!&lt;/b&gt; Opening links with your default browser will harm your security and anonymity.&lt;br&gt;&lt;br&gt;You can &lt;a href=&apos;.&apos;&gt;copy to the clipboard&lt;/a&gt; instead.</source>
         <extracomment>Label displayed when user clicks on a link</extracomment>
-        <translation>&lt;b&gt;Waarschuwing!&lt;/b&gt; Het openen van links met je standaard browser schaadt je beveliging en anonimiteit.&lt;br&gt;&lt;br&gt;Je kunt in plaats daarvan &lt;a href=&apos;.&apos;&gt;kopiëren maar het klembord&lt;/a&gt;.</translation>
+        <translation type="vanished">&lt;b&gt;Waarschuwing!&lt;/b&gt; Het openen van links met je standaard browser schaadt je beveliging en anonimiteit.&lt;br&gt;&lt;br&gt;Je kunt in plaats daarvan &lt;a href=&apos;.&apos;&gt;kopiëren maar het klembord&lt;/a&gt;.</translation>
     </message>
     <message>
         <source>Don&apos;t ask again for links from %1</source>
         <translation type="vanished">Vraag niet opnieuw om links van %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="50"/>
-        <source>Warning</source>
-        <extracomment>Name of warning label used with accessibility tech such as screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="65"/>
         <source>Don&apos;t ask again for any links (not recommended!)</source>
         <extracomment>Checkbox option text for when user clicks on a link</extracomment>
-        <translation>Vraag niet meer naar links (niet aanbevolen!)</translation>
+        <translation type="vanished">Vraag niet meer naar links (niet aanbevolen!)</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="73"/>
         <source>Open Browser</source>
         <extracomment>Label on button to open link in a web browser</extracomment>
-        <translation>Open Browser</translation>
+        <translation type="vanished">Open Browser</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="84"/>
         <source>Cancel</source>
         <extracomment>Label on cancel button</extracomment>
-        <translation>Annuleren</translation>
+        <translation type="vanished">Annuleren</translation>
     </message>
 </context>
 <context>
@@ -878,144 +877,144 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>Heeft deze computer een proxy nodig om te verbinden met het internet?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="69"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="70"/>
         <source>Proxy type:</source>
         <translation>Proxy type:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="74"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="75"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="77"/>
         <source>None</source>
         <translation>Geen</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="92"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="93"/>
         <source>If you need a proxy to access the internet, select one from this list.</source>
         <extracomment>Description used by accessibility tech, such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="97"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="98"/>
         <source>Address:</source>
         <extracomment>Label indicating the textbox to place a proxy IP or URL</extracomment>
         <translation>Adres:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="111"/>
         <source>IP address or hostname</source>
         <extracomment>Placeholder text of text box expecting an IP or URL for proxy</extracomment>
         <translation>IP adres of servernaam</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="115"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="116"/>
         <source>Enter the IP address or hostname of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the IP textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="119"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="120"/>
         <source>Port:</source>
         <extracomment>Label indicating the textbox to place a proxy port</extracomment>
         <translation>Poort:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="130"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="131"/>
         <source>Port</source>
         <extracomment>Name of the port label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="132"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="133"/>
         <source>Enter the port of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the Port textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="138"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="139"/>
         <source>Username:</source>
         <extracomment>Label indicating the textbox to place the proxy username</extracomment>
         <translation>Gebruikersnaam:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="152"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="173"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="153"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="174"/>
         <source>Optional</source>
         <extracomment>Textbox placeholder text indicating the field is not required</extracomment>
         <translation>Optioneel</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="156"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="157"/>
         <source>Username</source>
         <extracomment>Name of the username label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="158"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="159"/>
         <source>If required, enter the username for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Username textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="162"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="163"/>
         <source>Password:</source>
         <extracomment>Label indicating the textbox to place the proxy password</extracomment>
         <translation>Wachtwoord:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="177"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="178"/>
         <source>Password</source>
         <extracomment>Name of the password label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="180"/>
         <source>If required, enter the password for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Password textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="190"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="191"/>
         <source>Does this computer&apos;s Internet connection go through a firewall that only allows connections to certain ports?</source>
         <extracomment>Description for the purpose of the Allowed Ports textbox</extracomment>
         <translation>Gaat de internetverbinding van deze computer door een firewall die alleen verbindingen naar bepaalde poorten toestaat?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="211"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="212"/>
         <source>Allowed ports:</source>
         <extracomment>Label indicating the textbox to place the allowed ports</extracomment>
         <translation>Toegestane poorten:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="220"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="221"/>
         <source>Example: 80,443</source>
         <extracomment>Textbox showing an example entry for the firewall allowed ports entry</extracomment>
         <translation>Voorbeeld: 80,443</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="224"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="225"/>
         <source>Allowed ports</source>
         <extracomment>Name of the allowed ports label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="236"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="237"/>
         <source>If this computer&apos;s Internet connection is censored, you will need to obtain and use bridge relays.</source>
         <translation>Als de internetverbinding van deze computer is gecensureerd, moet je bridge relays vinden en gebruiken.</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="251"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="262"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="252"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="263"/>
         <source>Enter one or more bridge relays (one per line):</source>
         <translation>Geen een of meer bridge relays op (een per regel):</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="273"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="274"/>
         <source>Back</source>
         <extracomment>Button label for going back to previous screen</extracomment>
         <translation>Terug</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="284"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="285"/>
         <source>Connect</source>
         <extracomment>Button label for connecting to tor</extracomment>
         <translation>Verbinden</translation>
@@ -1192,51 +1191,65 @@ Name of the button for launching the preferences window for accessibility tech l
     </message>
     <message>
         <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="114"/>
+        <source>Accepted</source>
+        <translation type="unfinished">Geaccepteerd</translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="115"/>
         <source>Rejected</source>
         <translation type="unfinished">Afgewezen</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="120"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
         <source>Cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
         <source>Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
         <source>Unkown Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
         <source>Bad File Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
         <source>Network Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="126"/>
         <source>File System Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="127"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="128"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="220"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="223"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="395"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="285"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="289"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="295"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="309"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="350"/>
+        <source>me</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="436"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/tego_ui/translation/ricochet_pl.ts
+++ b/src/tego_ui/translation/ricochet_pl.ts
@@ -21,29 +21,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="36"/>
-        <source>Ricochet Refresh web home page</source>
-        <extracomment>provides context for the URL for accessibility tech like screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="59"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="32"/>
         <source>The license of Ricochet Refresh and its dependencies</source>
-        <extracomment>summary of a block of text for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="60"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="33"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="65"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="37"/>
         <source>About</source>
         <translation type="unfinished">O programie</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="39"/>
         <source>About page, contains license and version information</source>
         <extracomment>summary of the window&apos;s contents for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -105,37 +98,53 @@
 <context>
     <name>ContactActions</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="49"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <source>Could not successfully export conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="65"/>
         <source>Open Window</source>
         <extracomment>Context menu command to open the chat screen in a separate window</extracomment>
         <translation>Otwórz okno</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="70"/>
         <source>Details...</source>
         <extracomment>Context menu command to open a window showing the selected contact&apos;s details</extracomment>
         <translation>Szczegóły...</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="56"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="75"/>
         <source>Rename</source>
         <extracomment>Context menu command to rename the selected contact</extracomment>
         <translation>Zmień nazwę</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="61"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="80"/>
         <source>Send File...</source>
         <extracomment>Context menu command to initiate a file transfer, opens a system file dialog</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="85"/>
+        <source>Export Conversation</source>
+        <extracomment>Context menu command to initiate a chat log export, opens a system file dialog to export to</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="91"/>
         <source>Remove</source>
         <extracomment>Context menu command to remove a contact from the contact list</extracomment>
         <translation>Usuń</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="74"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="98"/>
         <source>Contact options</source>
         <extracomment>Description of the items in the context menu for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -151,30 +160,36 @@
     </message>
     <message>
         <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="45"/>
+        <source>This ID is invalid</source>
+        <extracomment>Error message showed when the id doesn&apos;t comply with spec https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
         <source>You can&apos;t add yourself as a contact</source>
         <extracomment>Error message showed when user attempts to add themselves as a contact in their contact list</extracomment>
         <translation>Nie możesz dodać siebie do kontaktów</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="55"/>
         <source>Enter an ID starting with &lt;b&gt;ricochet:&lt;/b&gt;</source>
         <extracomment>Error message showed when the provided ricochet id is invalid</extracomment>
         <translation>Wpisz ID zaczynające się od &lt;b&gt;ricochet:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="88"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="97"/>
         <source>Copied to clipboard</source>
         <extracomment>Message displayed when text is copied to the user&apos;s clipboard</extracomment>
         <translation>Skopiowano do schowka</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="103"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="112"/>
         <source>Copy</source>
         <extracomment>Text displayed on a button used to copy somethign to the user&apos;s clipboard</extracomment>
         <translation>Kopiuj</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="119"/>
         <source>Copies the ricochet id to the clipboard</source>
         <extracomment>Text description of ricochet id copy button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -397,20 +412,19 @@
         <translation>Używaj pojedynczego okno do rozmów</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Open links in default browser without prompting</source>
         <extracomment>Text description of an option to open URLs in default web browser when clicked</extracomment>
-        <translation>Otwórz linki w domyślnej przeglądarce bez pytania</translation>
+        <translation type="vanished">Otwórz linki w domyślnej przeglądarce bez pytania</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="44"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Play audio notifications</source>
         <extracomment>Text description of an option to play audio notifications when contacts log in, log out, and send messages</extracomment>
         <translation>Włącz powiadomienia dźwiękowe</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="61"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="77"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="62"/>
         <source>Volume</source>
         <extracomment>Label for a slider used to adjust audio notification volume
 ----------
@@ -418,8 +432,8 @@ Name of the slider used to adjust audio notification volume for accessibility te
         <translation>Głośność</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="91"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="129"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="114"/>
         <source>Language</source>
         <extracomment>Label for combobox where users can specify the UI language
 ----------
@@ -427,12 +441,12 @@ Name of the combobox used to select UI langauge for accessibility tech like scre
         <translation type="unfinished">Język</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="117"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="102"/>
         <source>Restart Ricochet to apply changes</source>
         <translation type="unfinished">Aby zaakceptować zmiany, uruchom Ricochet ponownie</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="131"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="116"/>
         <source>What language ricochet will use</source>
         <extracomment>Description of what the language combox is for for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -507,17 +521,17 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="157"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="151"/>
         <source>Version Seperator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="191"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="185"/>
         <source>Remove %1</source>
         <translation>Usuń %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="192"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="186"/>
         <source>Do you want to permanently remove %1?</source>
         <translation>Czy chcesz na stałe usunąć %1?</translation>
     </message>
@@ -549,79 +563,74 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>%1 jest rozłączony</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="169"/>
         <source>File transfer file name</source>
         <extracomment>Description of the text displaying the filename of a file transfer, used by accessibility tech like screen readres</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="195"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="185"/>
         <source>File transfer progress</source>
         <extracomment>Description of progress bar displaying the file transfer progress, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="210"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="200"/>
         <source>File transfer status</source>
         <extracomment>Description of label displaying the current status of a file transfer, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="225"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="215"/>
         <source>Download</source>
         <extracomment>Label for file transfer &apos;Download&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="227"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="217"/>
         <source>Download file</source>
         <extracomment>Description of what the file transfer &apos;Download&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="244"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="234"/>
         <source>Cancel or reject</source>
         <extracomment>Label for file transfer &apos;Cancel&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="246"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="236"/>
         <source>Cancels or rejects a file transfer</source>
         <extracomment>Description of what the file transfer &apos;Cancel&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="310"/>
         <source>Copy ID</source>
         <extracomment>Text for context menu command to copy a ricochet contact id to clipboard</extracomment>
-        <translation>Skopiuj ID</translation>
+        <translation type="vanished">Skopiuj ID</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="281"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="312"/>
         <source>Copy Link</source>
         <extracomment>Text for context menu command to copy a url to the clipboard</extracomment>
-        <translation>Skopiuj link</translation>
+        <translation type="vanished">Skopiuj link</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="287"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="318"/>
         <source>Open with Browser</source>
         <extracomment>Text for context menu command to open a url in a web browser</extracomment>
-        <translation>Otwórz w przeglądarce</translation>
+        <translation type="vanished">Otwórz w przeglądarce</translation>
     </message>
     <message>
         <source>Add as Contact</source>
         <translation type="vanished">Dodaj jako kontakt</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="335"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="262"/>
         <source>Copy Message</source>
         <extracomment>Text for context menu command to copy an entire message to clipboard</extracomment>
         <translation>Kopiuj wiadomość</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="343"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="270"/>
         <source>Copy Selection</source>
         <extracomment>Text for context menu command to copy selected text to clipboard</extracomment>
         <translation>Kopiuj zaznaczenie</translation>
@@ -705,38 +714,28 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>OpenBrowserDialog</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="41"/>
         <source>&lt;b&gt;Warning!&lt;/b&gt; Opening links with your default browser will harm your security and anonymity.&lt;br&gt;&lt;br&gt;You can &lt;a href=&apos;.&apos;&gt;copy to the clipboard&lt;/a&gt; instead.</source>
         <extracomment>Label displayed when user clicks on a link</extracomment>
-        <translation>&lt;b&gt;Uwaga!&lt;/b&gt; Otwieranie linków za pomocą domyślnej przeglądarki spowoduje utratę bezpieczeństwa i anonimowości. Zamiast tego możesz &lt;a href=&apos;.&apos;&gt;skopiować go do schowka&lt;/a&gt;</translation>
+        <translation type="vanished">&lt;b&gt;Uwaga!&lt;/b&gt; Otwieranie linków za pomocą domyślnej przeglądarki spowoduje utratę bezpieczeństwa i anonimowości. Zamiast tego możesz &lt;a href=&apos;.&apos;&gt;skopiować go do schowka&lt;/a&gt;</translation>
     </message>
     <message>
         <source>Don&apos;t ask again for links from %1</source>
         <translation type="vanished">Nie pytaj ponownie dla linków od %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="50"/>
-        <source>Warning</source>
-        <extracomment>Name of warning label used with accessibility tech such as screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="65"/>
         <source>Don&apos;t ask again for any links (not recommended!)</source>
         <extracomment>Checkbox option text for when user clicks on a link</extracomment>
-        <translation>Nigdy nie pytaj ponownie (niezalecane!)</translation>
+        <translation type="vanished">Nigdy nie pytaj ponownie (niezalecane!)</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="73"/>
         <source>Open Browser</source>
         <extracomment>Label on button to open link in a web browser</extracomment>
-        <translation>Otwórz przeglądarkę</translation>
+        <translation type="vanished">Otwórz przeglądarkę</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="84"/>
         <source>Cancel</source>
         <extracomment>Label on cancel button</extracomment>
-        <translation>Anuluj</translation>
+        <translation type="vanished">Anuluj</translation>
     </message>
 </context>
 <context>
@@ -878,144 +877,144 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>Czy ten komputer potrzebuje serwera proxy, aby łączyć się z Internetem?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="69"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="70"/>
         <source>Proxy type:</source>
         <translation>Typ proxy:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="74"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="75"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="77"/>
         <source>None</source>
         <translation>Brak</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="92"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="93"/>
         <source>If you need a proxy to access the internet, select one from this list.</source>
         <extracomment>Description used by accessibility tech, such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="97"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="98"/>
         <source>Address:</source>
         <extracomment>Label indicating the textbox to place a proxy IP or URL</extracomment>
         <translation>Adres:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="111"/>
         <source>IP address or hostname</source>
         <extracomment>Placeholder text of text box expecting an IP or URL for proxy</extracomment>
         <translation>Adres IP lub nazwa hosta</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="115"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="116"/>
         <source>Enter the IP address or hostname of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the IP textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="119"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="120"/>
         <source>Port:</source>
         <extracomment>Label indicating the textbox to place a proxy port</extracomment>
         <translation>Port:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="130"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="131"/>
         <source>Port</source>
         <extracomment>Name of the port label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="132"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="133"/>
         <source>Enter the port of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the Port textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="138"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="139"/>
         <source>Username:</source>
         <extracomment>Label indicating the textbox to place the proxy username</extracomment>
         <translation>Nazwa użytkownika:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="152"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="173"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="153"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="174"/>
         <source>Optional</source>
         <extracomment>Textbox placeholder text indicating the field is not required</extracomment>
         <translation>Opcjonalny</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="156"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="157"/>
         <source>Username</source>
         <extracomment>Name of the username label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="158"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="159"/>
         <source>If required, enter the username for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Username textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="162"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="163"/>
         <source>Password:</source>
         <extracomment>Label indicating the textbox to place the proxy password</extracomment>
         <translation>Hasło:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="177"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="178"/>
         <source>Password</source>
         <extracomment>Name of the password label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="180"/>
         <source>If required, enter the password for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Password textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="190"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="191"/>
         <source>Does this computer&apos;s Internet connection go through a firewall that only allows connections to certain ports?</source>
         <extracomment>Description for the purpose of the Allowed Ports textbox</extracomment>
         <translation>Czy połączenie internetowe tego komputera jest kierowane przez firewall, który pozwala na łączenie się tylko z wybranymi portami?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="211"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="212"/>
         <source>Allowed ports:</source>
         <extracomment>Label indicating the textbox to place the allowed ports</extracomment>
         <translation>Dozwolone porty:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="220"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="221"/>
         <source>Example: 80,443</source>
         <extracomment>Textbox showing an example entry for the firewall allowed ports entry</extracomment>
         <translation>Na przykład: 80,443</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="224"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="225"/>
         <source>Allowed ports</source>
         <extracomment>Name of the allowed ports label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="236"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="237"/>
         <source>If this computer&apos;s Internet connection is censored, you will need to obtain and use bridge relays.</source>
         <translation>Jeżeli połączenie internetowe tego komputera jest cenzurowane, będziesz musiał uzyskać dostęp do węzła pośredniego (&lt;i&gt;bridge relay&lt;/i&gt;).</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="251"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="262"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="252"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="263"/>
         <source>Enter one or more bridge relays (one per line):</source>
         <translation>Podaj jeden lub więcej węzłów pośrednich (jeden w linii):</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="273"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="274"/>
         <source>Back</source>
         <extracomment>Button label for going back to previous screen</extracomment>
         <translation>Wróć</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="284"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="285"/>
         <source>Connect</source>
         <extracomment>Button label for connecting to tor</extracomment>
         <translation>Połącz</translation>
@@ -1192,51 +1191,65 @@ Name of the button for launching the preferences window for accessibility tech l
     </message>
     <message>
         <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="114"/>
+        <source>Accepted</source>
+        <translation type="unfinished">Zaakceptowany</translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="115"/>
         <source>Rejected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="120"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
         <source>Cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
         <source>Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
         <source>Unkown Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
         <source>Bad File Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
         <source>Network Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="126"/>
         <source>File System Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="127"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="128"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="220"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="223"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="395"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="285"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="289"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="295"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="309"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="350"/>
+        <source>me</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="436"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/tego_ui/translation/ricochet_pt_BR.ts
+++ b/src/tego_ui/translation/ricochet_pt_BR.ts
@@ -21,29 +21,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="36"/>
-        <source>Ricochet Refresh web home page</source>
-        <extracomment>provides context for the URL for accessibility tech like screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="59"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="32"/>
         <source>The license of Ricochet Refresh and its dependencies</source>
-        <extracomment>summary of a block of text for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="60"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="33"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="65"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="37"/>
         <source>About</source>
         <translation type="unfinished">Sobre</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="39"/>
         <source>About page, contains license and version information</source>
         <extracomment>summary of the window&apos;s contents for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -105,37 +98,53 @@
 <context>
     <name>ContactActions</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="49"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <source>Could not successfully export conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="65"/>
         <source>Open Window</source>
         <extracomment>Context menu command to open the chat screen in a separate window</extracomment>
         <translation>Abrir Janela</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="70"/>
         <source>Details...</source>
         <extracomment>Context menu command to open a window showing the selected contact&apos;s details</extracomment>
         <translation>Detalhes...</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="56"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="75"/>
         <source>Rename</source>
         <extracomment>Context menu command to rename the selected contact</extracomment>
         <translation>Renomear</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="61"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="80"/>
         <source>Send File...</source>
         <extracomment>Context menu command to initiate a file transfer, opens a system file dialog</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="85"/>
+        <source>Export Conversation</source>
+        <extracomment>Context menu command to initiate a chat log export, opens a system file dialog to export to</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="91"/>
         <source>Remove</source>
         <extracomment>Context menu command to remove a contact from the contact list</extracomment>
         <translation>Remover</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="74"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="98"/>
         <source>Contact options</source>
         <extracomment>Description of the items in the context menu for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -151,30 +160,36 @@
     </message>
     <message>
         <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="45"/>
+        <source>This ID is invalid</source>
+        <extracomment>Error message showed when the id doesn&apos;t comply with spec https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
         <source>You can&apos;t add yourself as a contact</source>
         <extracomment>Error message showed when user attempts to add themselves as a contact in their contact list</extracomment>
         <translation>Você não pode adicionar a si mesmo como um contato</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="55"/>
         <source>Enter an ID starting with &lt;b&gt;ricochet:&lt;/b&gt;</source>
         <extracomment>Error message showed when the provided ricochet id is invalid</extracomment>
         <translation>Entre uma ID começando com &lt;b&gt;ricochet:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="88"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="97"/>
         <source>Copied to clipboard</source>
         <extracomment>Message displayed when text is copied to the user&apos;s clipboard</extracomment>
         <translation>Copiado para a área de transferência</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="103"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="112"/>
         <source>Copy</source>
         <extracomment>Text displayed on a button used to copy somethign to the user&apos;s clipboard</extracomment>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="119"/>
         <source>Copies the ricochet id to the clipboard</source>
         <extracomment>Text description of ricochet id copy button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -397,20 +412,19 @@
         <translation>Usar somente uma janela para conversas</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Open links in default browser without prompting</source>
         <extracomment>Text description of an option to open URLs in default web browser when clicked</extracomment>
-        <translation>Abrir links no navegador padrão sem pedir confirmação</translation>
+        <translation type="vanished">Abrir links no navegador padrão sem pedir confirmação</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="44"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Play audio notifications</source>
         <extracomment>Text description of an option to play audio notifications when contacts log in, log out, and send messages</extracomment>
         <translation>Tocar notificações de áudio</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="61"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="77"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="62"/>
         <source>Volume</source>
         <extracomment>Label for a slider used to adjust audio notification volume
 ----------
@@ -418,8 +432,8 @@ Name of the slider used to adjust audio notification volume for accessibility te
         <translation>Volume</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="91"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="129"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="114"/>
         <source>Language</source>
         <extracomment>Label for combobox where users can specify the UI language
 ----------
@@ -427,12 +441,12 @@ Name of the combobox used to select UI langauge for accessibility tech like scre
         <translation type="unfinished">Idioma</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="117"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="102"/>
         <source>Restart Ricochet to apply changes</source>
         <translation type="unfinished">Reiniciar Ricochet para aplicar mudanças</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="131"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="116"/>
         <source>What language ricochet will use</source>
         <extracomment>Description of what the language combox is for for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -507,17 +521,17 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="157"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="151"/>
         <source>Version Seperator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="191"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="185"/>
         <source>Remove %1</source>
         <translation>Remover %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="192"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="186"/>
         <source>Do you want to permanently remove %1?</source>
         <translation>Você deseja remover %1 permanentemente?</translation>
     </message>
@@ -549,79 +563,74 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>%1 está offline</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="169"/>
         <source>File transfer file name</source>
         <extracomment>Description of the text displaying the filename of a file transfer, used by accessibility tech like screen readres</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="195"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="185"/>
         <source>File transfer progress</source>
         <extracomment>Description of progress bar displaying the file transfer progress, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="210"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="200"/>
         <source>File transfer status</source>
         <extracomment>Description of label displaying the current status of a file transfer, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="225"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="215"/>
         <source>Download</source>
         <extracomment>Label for file transfer &apos;Download&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="227"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="217"/>
         <source>Download file</source>
         <extracomment>Description of what the file transfer &apos;Download&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="244"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="234"/>
         <source>Cancel or reject</source>
         <extracomment>Label for file transfer &apos;Cancel&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="246"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="236"/>
         <source>Cancels or rejects a file transfer</source>
         <extracomment>Description of what the file transfer &apos;Cancel&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="310"/>
         <source>Copy ID</source>
         <extracomment>Text for context menu command to copy a ricochet contact id to clipboard</extracomment>
-        <translation>Copiar ID</translation>
+        <translation type="vanished">Copiar ID</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="281"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="312"/>
         <source>Copy Link</source>
         <extracomment>Text for context menu command to copy a url to the clipboard</extracomment>
-        <translation>Copiar Link</translation>
+        <translation type="vanished">Copiar Link</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="287"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="318"/>
         <source>Open with Browser</source>
         <extracomment>Text for context menu command to open a url in a web browser</extracomment>
-        <translation>Abrir no Navegador</translation>
+        <translation type="vanished">Abrir no Navegador</translation>
     </message>
     <message>
         <source>Add as Contact</source>
         <translation type="vanished">Adicionar como Contato</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="335"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="262"/>
         <source>Copy Message</source>
         <extracomment>Text for context menu command to copy an entire message to clipboard</extracomment>
         <translation>Copiar Mensagem</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="343"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="270"/>
         <source>Copy Selection</source>
         <extracomment>Text for context menu command to copy selected text to clipboard</extracomment>
         <translation>Copiar Seleção</translation>
@@ -705,38 +714,28 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>OpenBrowserDialog</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="41"/>
         <source>&lt;b&gt;Warning!&lt;/b&gt; Opening links with your default browser will harm your security and anonymity.&lt;br&gt;&lt;br&gt;You can &lt;a href=&apos;.&apos;&gt;copy to the clipboard&lt;/a&gt; instead.</source>
         <extracomment>Label displayed when user clicks on a link</extracomment>
-        <translation>&lt;b&gt;Atenção!&lt;/b&gt; Abrir links com o seu navegador pode danificar sua segurança e anonimidade.&lt;br&gt;&lt;br&gt;Ao invés disso, você pode &lt;a href=&apos;.&apos;&gt;copiar para a área de transferência&lt;/a&gt;.</translation>
+        <translation type="vanished">&lt;b&gt;Atenção!&lt;/b&gt; Abrir links com o seu navegador pode danificar sua segurança e anonimidade.&lt;br&gt;&lt;br&gt;Ao invés disso, você pode &lt;a href=&apos;.&apos;&gt;copiar para a área de transferência&lt;/a&gt;.</translation>
     </message>
     <message>
         <source>Don&apos;t ask again for links from %1</source>
         <translation type="vanished">Não perguntar de novo para links de %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="50"/>
-        <source>Warning</source>
-        <extracomment>Name of warning label used with accessibility tech such as screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="65"/>
         <source>Don&apos;t ask again for any links (not recommended!)</source>
         <extracomment>Checkbox option text for when user clicks on a link</extracomment>
-        <translation>Não perguntar de novo para quaisquer links (não recomendado!)</translation>
+        <translation type="vanished">Não perguntar de novo para quaisquer links (não recomendado!)</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="73"/>
         <source>Open Browser</source>
         <extracomment>Label on button to open link in a web browser</extracomment>
-        <translation>Abrir Navegador</translation>
+        <translation type="vanished">Abrir Navegador</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="84"/>
         <source>Cancel</source>
         <extracomment>Label on cancel button</extracomment>
-        <translation>Cancelar</translation>
+        <translation type="vanished">Cancelar</translation>
     </message>
 </context>
 <context>
@@ -878,144 +877,144 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>Este computador precisa de um proxy para acessar a internet?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="69"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="70"/>
         <source>Proxy type:</source>
         <translation>Tipo de proxy:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="74"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="75"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="77"/>
         <source>None</source>
         <translation>Nenhum</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="92"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="93"/>
         <source>If you need a proxy to access the internet, select one from this list.</source>
         <extracomment>Description used by accessibility tech, such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="97"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="98"/>
         <source>Address:</source>
         <extracomment>Label indicating the textbox to place a proxy IP or URL</extracomment>
         <translation>Endereço:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="111"/>
         <source>IP address or hostname</source>
         <extracomment>Placeholder text of text box expecting an IP or URL for proxy</extracomment>
         <translation>Endereço IP ou nome do host</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="115"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="116"/>
         <source>Enter the IP address or hostname of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the IP textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="119"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="120"/>
         <source>Port:</source>
         <extracomment>Label indicating the textbox to place a proxy port</extracomment>
         <translation>Porta:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="130"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="131"/>
         <source>Port</source>
         <extracomment>Name of the port label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="132"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="133"/>
         <source>Enter the port of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the Port textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="138"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="139"/>
         <source>Username:</source>
         <extracomment>Label indicating the textbox to place the proxy username</extracomment>
         <translation>Usuário:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="152"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="173"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="153"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="174"/>
         <source>Optional</source>
         <extracomment>Textbox placeholder text indicating the field is not required</extracomment>
         <translation>Opcional</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="156"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="157"/>
         <source>Username</source>
         <extracomment>Name of the username label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="158"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="159"/>
         <source>If required, enter the username for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Username textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="162"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="163"/>
         <source>Password:</source>
         <extracomment>Label indicating the textbox to place the proxy password</extracomment>
         <translation>Senha:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="177"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="178"/>
         <source>Password</source>
         <extracomment>Name of the password label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="180"/>
         <source>If required, enter the password for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Password textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="190"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="191"/>
         <source>Does this computer&apos;s Internet connection go through a firewall that only allows connections to certain ports?</source>
         <extracomment>Description for the purpose of the Allowed Ports textbox</extracomment>
         <translation>A conexão à internet deste computador passa por um firewall que só permite conexões a certas portas?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="211"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="212"/>
         <source>Allowed ports:</source>
         <extracomment>Label indicating the textbox to place the allowed ports</extracomment>
         <translation>Portas permitidas:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="220"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="221"/>
         <source>Example: 80,443</source>
         <extracomment>Textbox showing an example entry for the firewall allowed ports entry</extracomment>
         <translation>Exemplo: 80,443</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="224"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="225"/>
         <source>Allowed ports</source>
         <extracomment>Name of the allowed ports label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="236"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="237"/>
         <source>If this computer&apos;s Internet connection is censored, you will need to obtain and use bridge relays.</source>
         <translation>Se a conexão à internet deste computador é censurada, você precisará obter e usar bridge relays.</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="251"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="262"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="252"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="263"/>
         <source>Enter one or more bridge relays (one per line):</source>
         <translation>Entre um ou mais bridge relays (um por linha):</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="273"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="274"/>
         <source>Back</source>
         <extracomment>Button label for going back to previous screen</extracomment>
         <translation>Voltar</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="284"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="285"/>
         <source>Connect</source>
         <extracomment>Button label for connecting to tor</extracomment>
         <translation>Conectar</translation>
@@ -1192,51 +1191,65 @@ Name of the button for launching the preferences window for accessibility tech l
     </message>
     <message>
         <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="114"/>
+        <source>Accepted</source>
+        <translation type="unfinished">Aceito</translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="115"/>
         <source>Rejected</source>
         <translation type="unfinished">Rejeitado</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="120"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
         <source>Cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
         <source>Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
         <source>Unkown Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
         <source>Bad File Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
         <source>Network Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="126"/>
         <source>File System Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="127"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="128"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="220"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="223"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="395"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="285"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="289"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="295"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="309"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="350"/>
+        <source>me</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="436"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/tego_ui/translation/ricochet_pt_PT.ts
+++ b/src/tego_ui/translation/ricochet_pt_PT.ts
@@ -21,29 +21,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="36"/>
-        <source>Ricochet Refresh web home page</source>
-        <extracomment>provides context for the URL for accessibility tech like screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="59"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="32"/>
         <source>The license of Ricochet Refresh and its dependencies</source>
-        <extracomment>summary of a block of text for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="60"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="33"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="65"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="37"/>
         <source>About</source>
         <translation type="unfinished">Sobre</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="39"/>
         <source>About page, contains license and version information</source>
         <extracomment>summary of the window&apos;s contents for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -105,37 +98,53 @@
 <context>
     <name>ContactActions</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="49"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <source>Could not successfully export conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="65"/>
         <source>Open Window</source>
         <extracomment>Context menu command to open the chat screen in a separate window</extracomment>
         <translation>Abrir Janela</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="70"/>
         <source>Details...</source>
         <extracomment>Context menu command to open a window showing the selected contact&apos;s details</extracomment>
         <translation>Detalhes...</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="56"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="75"/>
         <source>Rename</source>
         <extracomment>Context menu command to rename the selected contact</extracomment>
         <translation>Mudar o nome</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="61"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="80"/>
         <source>Send File...</source>
         <extracomment>Context menu command to initiate a file transfer, opens a system file dialog</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="85"/>
+        <source>Export Conversation</source>
+        <extracomment>Context menu command to initiate a chat log export, opens a system file dialog to export to</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="91"/>
         <source>Remove</source>
         <extracomment>Context menu command to remove a contact from the contact list</extracomment>
         <translation>Remover</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="74"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="98"/>
         <source>Contact options</source>
         <extracomment>Description of the items in the context menu for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -151,30 +160,36 @@
     </message>
     <message>
         <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="45"/>
+        <source>This ID is invalid</source>
+        <extracomment>Error message showed when the id doesn&apos;t comply with spec https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
         <source>You can&apos;t add yourself as a contact</source>
         <extracomment>Error message showed when user attempts to add themselves as a contact in their contact list</extracomment>
         <translation>Não pode adicionar-se a si mesmo como contacto</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="55"/>
         <source>Enter an ID starting with &lt;b&gt;ricochet:&lt;/b&gt;</source>
         <extracomment>Error message showed when the provided ricochet id is invalid</extracomment>
         <translation>Insira um ID que comece com &lt;b&gt;ricochet:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="88"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="97"/>
         <source>Copied to clipboard</source>
         <extracomment>Message displayed when text is copied to the user&apos;s clipboard</extracomment>
         <translation>Copiado para a área de transferência</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="103"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="112"/>
         <source>Copy</source>
         <extracomment>Text displayed on a button used to copy somethign to the user&apos;s clipboard</extracomment>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="119"/>
         <source>Copies the ricochet id to the clipboard</source>
         <extracomment>Text description of ricochet id copy button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -397,20 +412,19 @@
         <translation>Utilizar uma única janela para conversas</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Open links in default browser without prompting</source>
         <extracomment>Text description of an option to open URLs in default web browser when clicked</extracomment>
-        <translation>Abrir links no navegador padrão sem pedir confirmação</translation>
+        <translation type="vanished">Abrir links no navegador padrão sem pedir confirmação</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="44"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Play audio notifications</source>
         <extracomment>Text description of an option to play audio notifications when contacts log in, log out, and send messages</extracomment>
         <translation>Ativar notificações de áudio</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="61"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="77"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="62"/>
         <source>Volume</source>
         <extracomment>Label for a slider used to adjust audio notification volume
 ----------
@@ -418,8 +432,8 @@ Name of the slider used to adjust audio notification volume for accessibility te
         <translation>Volume</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="91"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="129"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="114"/>
         <source>Language</source>
         <extracomment>Label for combobox where users can specify the UI language
 ----------
@@ -427,12 +441,12 @@ Name of the combobox used to select UI langauge for accessibility tech like scre
         <translation type="unfinished">Idioma</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="117"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="102"/>
         <source>Restart Ricochet to apply changes</source>
         <translation type="unfinished">Reiniciar o Ricochet para aplicar as alterações</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="131"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="116"/>
         <source>What language ricochet will use</source>
         <extracomment>Description of what the language combox is for for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -507,17 +521,17 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="157"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="151"/>
         <source>Version Seperator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="191"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="185"/>
         <source>Remove %1</source>
         <translation>Remover %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="192"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="186"/>
         <source>Do you want to permanently remove %1?</source>
         <translation>Deseja remover %1 permanentemente?</translation>
     </message>
@@ -549,79 +563,74 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>%1 está offline</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="169"/>
         <source>File transfer file name</source>
         <extracomment>Description of the text displaying the filename of a file transfer, used by accessibility tech like screen readres</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="195"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="185"/>
         <source>File transfer progress</source>
         <extracomment>Description of progress bar displaying the file transfer progress, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="210"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="200"/>
         <source>File transfer status</source>
         <extracomment>Description of label displaying the current status of a file transfer, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="225"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="215"/>
         <source>Download</source>
         <extracomment>Label for file transfer &apos;Download&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="227"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="217"/>
         <source>Download file</source>
         <extracomment>Description of what the file transfer &apos;Download&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="244"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="234"/>
         <source>Cancel or reject</source>
         <extracomment>Label for file transfer &apos;Cancel&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="246"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="236"/>
         <source>Cancels or rejects a file transfer</source>
         <extracomment>Description of what the file transfer &apos;Cancel&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="310"/>
         <source>Copy ID</source>
         <extracomment>Text for context menu command to copy a ricochet contact id to clipboard</extracomment>
-        <translation>Copiar ID</translation>
+        <translation type="vanished">Copiar ID</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="281"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="312"/>
         <source>Copy Link</source>
         <extracomment>Text for context menu command to copy a url to the clipboard</extracomment>
-        <translation>Copiar Link</translation>
+        <translation type="vanished">Copiar Link</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="287"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="318"/>
         <source>Open with Browser</source>
         <extracomment>Text for context menu command to open a url in a web browser</extracomment>
-        <translation>Abrir com o Navegador</translation>
+        <translation type="vanished">Abrir com o Navegador</translation>
     </message>
     <message>
         <source>Add as Contact</source>
         <translation type="vanished">Adicionar como Contacto</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="335"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="262"/>
         <source>Copy Message</source>
         <extracomment>Text for context menu command to copy an entire message to clipboard</extracomment>
         <translation>Copiar Mensagem</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="343"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="270"/>
         <source>Copy Selection</source>
         <extracomment>Text for context menu command to copy selected text to clipboard</extracomment>
         <translation>Copiar Seleção</translation>
@@ -705,38 +714,28 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>OpenBrowserDialog</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="41"/>
         <source>&lt;b&gt;Warning!&lt;/b&gt; Opening links with your default browser will harm your security and anonymity.&lt;br&gt;&lt;br&gt;You can &lt;a href=&apos;.&apos;&gt;copy to the clipboard&lt;/a&gt; instead.</source>
         <extracomment>Label displayed when user clicks on a link</extracomment>
-        <translation>&lt;b&gt;Atenção!&lt;/b&gt; Abrir links com o seu navegador padrão irá diminuir a sua segurança e anonimidade.&lt;br&gt;&lt;br&gt;Em vez disso, poderá &lt;a href=&apos;.&apos;&gt;copiar para a área de transferência&lt;/a&gt;.</translation>
+        <translation type="vanished">&lt;b&gt;Atenção!&lt;/b&gt; Abrir links com o seu navegador padrão irá diminuir a sua segurança e anonimidade.&lt;br&gt;&lt;br&gt;Em vez disso, poderá &lt;a href=&apos;.&apos;&gt;copiar para a área de transferência&lt;/a&gt;.</translation>
     </message>
     <message>
         <source>Don&apos;t ask again for links from %1</source>
         <translation type="vanished">Não perguntar de novo para links de %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="50"/>
-        <source>Warning</source>
-        <extracomment>Name of warning label used with accessibility tech such as screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="65"/>
         <source>Don&apos;t ask again for any links (not recommended!)</source>
         <extracomment>Checkbox option text for when user clicks on a link</extracomment>
-        <translation>Não perguntar de novo para quaisquer links (não recomendado!)</translation>
+        <translation type="vanished">Não perguntar de novo para quaisquer links (não recomendado!)</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="73"/>
         <source>Open Browser</source>
         <extracomment>Label on button to open link in a web browser</extracomment>
-        <translation>Abrir Navegador</translation>
+        <translation type="vanished">Abrir Navegador</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="84"/>
         <source>Cancel</source>
         <extracomment>Label on cancel button</extracomment>
-        <translation>Cancelar</translation>
+        <translation type="vanished">Cancelar</translation>
     </message>
 </context>
 <context>
@@ -878,144 +877,144 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>Este computador necessita de um proxy para aceder à internet?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="69"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="70"/>
         <source>Proxy type:</source>
         <translation>Tipo de proxy:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="74"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="75"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="77"/>
         <source>None</source>
         <translation>Nenhum</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="92"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="93"/>
         <source>If you need a proxy to access the internet, select one from this list.</source>
         <extracomment>Description used by accessibility tech, such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="97"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="98"/>
         <source>Address:</source>
         <extracomment>Label indicating the textbox to place a proxy IP or URL</extracomment>
         <translation>Endereço:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="111"/>
         <source>IP address or hostname</source>
         <extracomment>Placeholder text of text box expecting an IP or URL for proxy</extracomment>
         <translation>Endereço de IP ou nome do host</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="115"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="116"/>
         <source>Enter the IP address or hostname of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the IP textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="119"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="120"/>
         <source>Port:</source>
         <extracomment>Label indicating the textbox to place a proxy port</extracomment>
         <translation>Porta:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="130"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="131"/>
         <source>Port</source>
         <extracomment>Name of the port label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="132"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="133"/>
         <source>Enter the port of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the Port textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="138"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="139"/>
         <source>Username:</source>
         <extracomment>Label indicating the textbox to place the proxy username</extracomment>
         <translation>Nome de utilizador:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="152"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="173"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="153"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="174"/>
         <source>Optional</source>
         <extracomment>Textbox placeholder text indicating the field is not required</extracomment>
         <translation>Opcional</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="156"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="157"/>
         <source>Username</source>
         <extracomment>Name of the username label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="158"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="159"/>
         <source>If required, enter the username for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Username textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="162"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="163"/>
         <source>Password:</source>
         <extracomment>Label indicating the textbox to place the proxy password</extracomment>
         <translation>Palavra-passe:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="177"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="178"/>
         <source>Password</source>
         <extracomment>Name of the password label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="180"/>
         <source>If required, enter the password for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Password textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="190"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="191"/>
         <source>Does this computer&apos;s Internet connection go through a firewall that only allows connections to certain ports?</source>
         <extracomment>Description for the purpose of the Allowed Ports textbox</extracomment>
         <translation>A ligação à Internet deste computador passa por uma firewall que apenas permite ligações por certas portas?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="211"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="212"/>
         <source>Allowed ports:</source>
         <extracomment>Label indicating the textbox to place the allowed ports</extracomment>
         <translation>Portas permitidas:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="220"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="221"/>
         <source>Example: 80,443</source>
         <extracomment>Textbox showing an example entry for the firewall allowed ports entry</extracomment>
         <translation>Exemplo: 80,443</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="224"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="225"/>
         <source>Allowed ports</source>
         <extracomment>Name of the allowed ports label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="236"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="237"/>
         <source>If this computer&apos;s Internet connection is censored, you will need to obtain and use bridge relays.</source>
         <translation>Se a ligação à Internet deste computador é censurada, necessitará de obter e utilizar bridge relays.</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="251"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="262"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="252"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="263"/>
         <source>Enter one or more bridge relays (one per line):</source>
         <translation>Insira um ou mais bridge relays (um por linha):</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="273"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="274"/>
         <source>Back</source>
         <extracomment>Button label for going back to previous screen</extracomment>
         <translation>Voltar</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="284"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="285"/>
         <source>Connect</source>
         <extracomment>Button label for connecting to tor</extracomment>
         <translation>Ligar</translation>
@@ -1192,51 +1191,65 @@ Name of the button for launching the preferences window for accessibility tech l
     </message>
     <message>
         <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="114"/>
+        <source>Accepted</source>
+        <translation type="unfinished">Aceite</translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="115"/>
         <source>Rejected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="120"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
         <source>Cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
         <source>Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
         <source>Unkown Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
         <source>Bad File Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
         <source>Network Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="126"/>
         <source>File System Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="127"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="128"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="220"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="223"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="395"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="285"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="289"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="295"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="309"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="350"/>
+        <source>me</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="436"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/tego_ui/translation/ricochet_ru.ts
+++ b/src/tego_ui/translation/ricochet_ru.ts
@@ -21,29 +21,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="36"/>
-        <source>Ricochet Refresh web home page</source>
-        <extracomment>provides context for the URL for accessibility tech like screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="59"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="32"/>
         <source>The license of Ricochet Refresh and its dependencies</source>
-        <extracomment>summary of a block of text for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="60"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="33"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="65"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="37"/>
         <source>About</source>
         <translation type="unfinished">О программе</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="39"/>
         <source>About page, contains license and version information</source>
         <extracomment>summary of the window&apos;s contents for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -105,37 +98,53 @@
 <context>
     <name>ContactActions</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="49"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <source>Could not successfully export conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="65"/>
         <source>Open Window</source>
         <extracomment>Context menu command to open the chat screen in a separate window</extracomment>
         <translation>Открыть окно</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="70"/>
         <source>Details...</source>
         <extracomment>Context menu command to open a window showing the selected contact&apos;s details</extracomment>
         <translation>Подробнее...</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="56"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="75"/>
         <source>Rename</source>
         <extracomment>Context menu command to rename the selected contact</extracomment>
         <translation>Переименовать</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="61"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="80"/>
         <source>Send File...</source>
         <extracomment>Context menu command to initiate a file transfer, opens a system file dialog</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="85"/>
+        <source>Export Conversation</source>
+        <extracomment>Context menu command to initiate a chat log export, opens a system file dialog to export to</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="91"/>
         <source>Remove</source>
         <extracomment>Context menu command to remove a contact from the contact list</extracomment>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="74"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="98"/>
         <source>Contact options</source>
         <extracomment>Description of the items in the context menu for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -151,30 +160,36 @@
     </message>
     <message>
         <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="45"/>
+        <source>This ID is invalid</source>
+        <extracomment>Error message showed when the id doesn&apos;t comply with spec https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
         <source>You can&apos;t add yourself as a contact</source>
         <extracomment>Error message showed when user attempts to add themselves as a contact in their contact list</extracomment>
         <translation>Вы не можете добавить себя в свой же список контактов</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="55"/>
         <source>Enter an ID starting with &lt;b&gt;ricochet:&lt;/b&gt;</source>
         <extracomment>Error message showed when the provided ricochet id is invalid</extracomment>
         <translation>Введите ID, начинающийся с &lt;b&gt;ricochet:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="88"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="97"/>
         <source>Copied to clipboard</source>
         <extracomment>Message displayed when text is copied to the user&apos;s clipboard</extracomment>
         <translation>Скопировано в буфер</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="103"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="112"/>
         <source>Copy</source>
         <extracomment>Text displayed on a button used to copy somethign to the user&apos;s clipboard</extracomment>
         <translation>Копировать</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="119"/>
         <source>Copies the ricochet id to the clipboard</source>
         <extracomment>Text description of ricochet id copy button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -393,20 +408,19 @@
         <translation>Использовать одно окно для разговоров</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Open links in default browser without prompting</source>
         <extracomment>Text description of an option to open URLs in default web browser when clicked</extracomment>
-        <translation>Открывать ссылки в браузере по умолчанию без запроса</translation>
+        <translation type="vanished">Открывать ссылки в браузере по умолчанию без запроса</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="44"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Play audio notifications</source>
         <extracomment>Text description of an option to play audio notifications when contacts log in, log out, and send messages</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="61"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="77"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="62"/>
         <source>Volume</source>
         <extracomment>Label for a slider used to adjust audio notification volume
 ----------
@@ -414,8 +428,8 @@ Name of the slider used to adjust audio notification volume for accessibility te
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="91"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="129"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="114"/>
         <source>Language</source>
         <extracomment>Label for combobox where users can specify the UI language
 ----------
@@ -423,12 +437,12 @@ Name of the combobox used to select UI langauge for accessibility tech like scre
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="117"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="102"/>
         <source>Restart Ricochet to apply changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="131"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="116"/>
         <source>What language ricochet will use</source>
         <extracomment>Description of what the language combox is for for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -492,17 +506,17 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="157"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="151"/>
         <source>Version Seperator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="191"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="185"/>
         <source>Remove %1</source>
         <translation>Удалить %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="192"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="186"/>
         <source>Do you want to permanently remove %1?</source>
         <translation>Вы действительно хотите удалить %1 навсегда?</translation>
     </message>
@@ -534,79 +548,74 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>%1 не в сети</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="169"/>
         <source>File transfer file name</source>
         <extracomment>Description of the text displaying the filename of a file transfer, used by accessibility tech like screen readres</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="195"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="185"/>
         <source>File transfer progress</source>
         <extracomment>Description of progress bar displaying the file transfer progress, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="210"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="200"/>
         <source>File transfer status</source>
         <extracomment>Description of label displaying the current status of a file transfer, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="225"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="215"/>
         <source>Download</source>
         <extracomment>Label for file transfer &apos;Download&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="227"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="217"/>
         <source>Download file</source>
         <extracomment>Description of what the file transfer &apos;Download&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="244"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="234"/>
         <source>Cancel or reject</source>
         <extracomment>Label for file transfer &apos;Cancel&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="246"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="236"/>
         <source>Cancels or rejects a file transfer</source>
         <extracomment>Description of what the file transfer &apos;Cancel&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="310"/>
         <source>Copy ID</source>
         <extracomment>Text for context menu command to copy a ricochet contact id to clipboard</extracomment>
-        <translation>Копировать ID</translation>
+        <translation type="vanished">Копировать ID</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="281"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="312"/>
         <source>Copy Link</source>
         <extracomment>Text for context menu command to copy a url to the clipboard</extracomment>
-        <translation>Копировать ссылку</translation>
+        <translation type="vanished">Копировать ссылку</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="287"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="318"/>
         <source>Open with Browser</source>
         <extracomment>Text for context menu command to open a url in a web browser</extracomment>
-        <translation>Открыть в браузере</translation>
+        <translation type="vanished">Открыть в браузере</translation>
     </message>
     <message>
         <source>Add as Contact</source>
         <translation type="vanished">Добавить в список контактов</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="335"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="262"/>
         <source>Copy Message</source>
         <extracomment>Text for context menu command to copy an entire message to clipboard</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="343"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="270"/>
         <source>Copy Selection</source>
         <extracomment>Text for context menu command to copy selected text to clipboard</extracomment>
         <translation type="unfinished"></translation>
@@ -690,38 +699,28 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>OpenBrowserDialog</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="41"/>
         <source>&lt;b&gt;Warning!&lt;/b&gt; Opening links with your default browser will harm your security and anonymity.&lt;br&gt;&lt;br&gt;You can &lt;a href=&apos;.&apos;&gt;copy to the clipboard&lt;/a&gt; instead.</source>
         <extracomment>Label displayed when user clicks on a link</extracomment>
-        <translation>&lt;b&gt;Внимание!&lt;/b&gt; Открывая ссылки браузером по умолчанию Вы можете нарушить Вашу безопасность и анонимность.&lt;br&gt;&lt;br&gt;Вместо этого Вы можете &lt;a href=&apos;.&apos;&gt;скопировать ссылку&lt;/a&gt;.</translation>
+        <translation type="vanished">&lt;b&gt;Внимание!&lt;/b&gt; Открывая ссылки браузером по умолчанию Вы можете нарушить Вашу безопасность и анонимность.&lt;br&gt;&lt;br&gt;Вместо этого Вы можете &lt;a href=&apos;.&apos;&gt;скопировать ссылку&lt;/a&gt;.</translation>
     </message>
     <message>
         <source>Don&apos;t ask again for links from %1</source>
         <translation type="vanished">Не спрашивать при открытии последующих ссылок от %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="50"/>
-        <source>Warning</source>
-        <extracomment>Name of warning label used with accessibility tech such as screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="65"/>
         <source>Don&apos;t ask again for any links (not recommended!)</source>
         <extracomment>Checkbox option text for when user clicks on a link</extracomment>
-        <translation>Не спрашивать при открытии всех последующих ссылок (не рекомендуется!)</translation>
+        <translation type="vanished">Не спрашивать при открытии всех последующих ссылок (не рекомендуется!)</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="73"/>
         <source>Open Browser</source>
         <extracomment>Label on button to open link in a web browser</extracomment>
-        <translation>Открыть браузер</translation>
+        <translation type="vanished">Открыть браузер</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="84"/>
         <source>Cancel</source>
         <extracomment>Label on cancel button</extracomment>
-        <translation>Отмена</translation>
+        <translation type="vanished">Отмена</translation>
     </message>
 </context>
 <context>
@@ -859,144 +858,144 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>Этот компьютер использует прокси для доступа в Интернет?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="69"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="70"/>
         <source>Proxy type:</source>
         <translation>Тип прокси:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="74"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="75"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="77"/>
         <source>None</source>
         <translation>Нет</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="92"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="93"/>
         <source>If you need a proxy to access the internet, select one from this list.</source>
         <extracomment>Description used by accessibility tech, such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="97"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="98"/>
         <source>Address:</source>
         <extracomment>Label indicating the textbox to place a proxy IP or URL</extracomment>
         <translation>Адрес:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="111"/>
         <source>IP address or hostname</source>
         <extracomment>Placeholder text of text box expecting an IP or URL for proxy</extracomment>
         <translation>IP адрес или имя хоста</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="115"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="116"/>
         <source>Enter the IP address or hostname of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the IP textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="119"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="120"/>
         <source>Port:</source>
         <extracomment>Label indicating the textbox to place a proxy port</extracomment>
         <translation>Порт:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="130"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="131"/>
         <source>Port</source>
         <extracomment>Name of the port label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="132"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="133"/>
         <source>Enter the port of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the Port textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="138"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="139"/>
         <source>Username:</source>
         <extracomment>Label indicating the textbox to place the proxy username</extracomment>
         <translation>Имя пользователя:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="152"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="173"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="153"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="174"/>
         <source>Optional</source>
         <extracomment>Textbox placeholder text indicating the field is not required</extracomment>
         <translation>Необязательно</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="156"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="157"/>
         <source>Username</source>
         <extracomment>Name of the username label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="158"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="159"/>
         <source>If required, enter the username for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Username textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="162"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="163"/>
         <source>Password:</source>
         <extracomment>Label indicating the textbox to place the proxy password</extracomment>
         <translation>Пароль:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="177"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="178"/>
         <source>Password</source>
         <extracomment>Name of the password label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="180"/>
         <source>If required, enter the password for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Password textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="190"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="191"/>
         <source>Does this computer&apos;s Internet connection go through a firewall that only allows connections to certain ports?</source>
         <extracomment>Description for the purpose of the Allowed Ports textbox</extracomment>
         <translation>Соединение данного компьютера фильтруется фаерволом, который разрешает доступ только к определенным портам?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="211"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="212"/>
         <source>Allowed ports:</source>
         <extracomment>Label indicating the textbox to place the allowed ports</extracomment>
         <translation>Открытые порты:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="220"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="221"/>
         <source>Example: 80,443</source>
         <extracomment>Textbox showing an example entry for the firewall allowed ports entry</extracomment>
         <translation>Например: 80,443</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="224"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="225"/>
         <source>Allowed ports</source>
         <extracomment>Name of the allowed ports label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="236"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="237"/>
         <source>If this computer&apos;s Internet connection is censored, you will need to obtain and use bridge relays.</source>
         <translation>Если соединение этого компьютера подвергается цензуре, Вам необходимо получить и использовать ретрансляторы Tor.</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="251"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="262"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="252"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="263"/>
         <source>Enter one or more bridge relays (one per line):</source>
         <translation>Введите один ретранслятор или более (по одному на строку):</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="273"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="274"/>
         <source>Back</source>
         <extracomment>Button label for going back to previous screen</extracomment>
         <translation>Назад</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="284"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="285"/>
         <source>Connect</source>
         <extracomment>Button label for connecting to tor</extracomment>
         <translation>Соединить</translation>
@@ -1173,51 +1172,65 @@ Name of the button for launching the preferences window for accessibility tech l
     </message>
     <message>
         <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="114"/>
+        <source>Accepted</source>
+        <translation type="unfinished">Принято</translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="115"/>
         <source>Rejected</source>
         <translation type="unfinished">Отказано</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="120"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
         <source>Cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
         <source>Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
         <source>Unkown Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
         <source>Bad File Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
         <source>Network Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="126"/>
         <source>File System Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="127"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="128"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="220"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="223"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="395"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="285"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="289"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="295"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="309"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="350"/>
+        <source>me</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="436"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/tego_ui/translation/ricochet_sl.ts
+++ b/src/tego_ui/translation/ricochet_sl.ts
@@ -21,29 +21,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="36"/>
-        <source>Ricochet Refresh web home page</source>
-        <extracomment>provides context for the URL for accessibility tech like screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="59"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="32"/>
         <source>The license of Ricochet Refresh and its dependencies</source>
-        <extracomment>summary of a block of text for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="60"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="33"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="65"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="37"/>
         <source>About</source>
         <translation type="unfinished">Več o</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="39"/>
         <source>About page, contains license and version information</source>
         <extracomment>summary of the window&apos;s contents for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -105,37 +98,53 @@
 <context>
     <name>ContactActions</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="49"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <source>Could not successfully export conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="65"/>
         <source>Open Window</source>
         <extracomment>Context menu command to open the chat screen in a separate window</extracomment>
         <translation>Odpri Okno</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="70"/>
         <source>Details...</source>
         <extracomment>Context menu command to open a window showing the selected contact&apos;s details</extracomment>
         <translation>Podrobnosti...</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="56"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="75"/>
         <source>Rename</source>
         <extracomment>Context menu command to rename the selected contact</extracomment>
         <translation>Preimenuj</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="61"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="80"/>
         <source>Send File...</source>
         <extracomment>Context menu command to initiate a file transfer, opens a system file dialog</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="85"/>
+        <source>Export Conversation</source>
+        <extracomment>Context menu command to initiate a chat log export, opens a system file dialog to export to</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="91"/>
         <source>Remove</source>
         <extracomment>Context menu command to remove a contact from the contact list</extracomment>
         <translation>Odstrani</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="74"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="98"/>
         <source>Contact options</source>
         <extracomment>Description of the items in the context menu for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -151,30 +160,36 @@
     </message>
     <message>
         <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="45"/>
+        <source>This ID is invalid</source>
+        <extracomment>Error message showed when the id doesn&apos;t comply with spec https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
         <source>You can&apos;t add yourself as a contact</source>
         <extracomment>Error message showed when user attempts to add themselves as a contact in their contact list</extracomment>
         <translation>Sebe ne moreš dodati med stike</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="55"/>
         <source>Enter an ID starting with &lt;b&gt;ricochet:&lt;/b&gt;</source>
         <extracomment>Error message showed when the provided ricochet id is invalid</extracomment>
         <translation>Vnesi ID,  tako da začneš vnos z &lt;b&gt;ricochet:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="88"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="97"/>
         <source>Copied to clipboard</source>
         <extracomment>Message displayed when text is copied to the user&apos;s clipboard</extracomment>
         <translation>Kopirano v odložišče</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="103"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="112"/>
         <source>Copy</source>
         <extracomment>Text displayed on a button used to copy somethign to the user&apos;s clipboard</extracomment>
         <translation>Kopiraj</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="119"/>
         <source>Copies the ricochet id to the clipboard</source>
         <extracomment>Text description of ricochet id copy button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -397,20 +412,19 @@
         <translation>Uporabljaj enotno okno za pogovore</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Open links in default browser without prompting</source>
         <extracomment>Text description of an option to open URLs in default web browser when clicked</extracomment>
-        <translation>Brez spraševanja odpri povezave v privzetem brskalniku</translation>
+        <translation type="vanished">Brez spraševanja odpri povezave v privzetem brskalniku</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="44"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Play audio notifications</source>
         <extracomment>Text description of an option to play audio notifications when contacts log in, log out, and send messages</extracomment>
         <translation>Predvajaj zvočna obvestila   </translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="61"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="77"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="62"/>
         <source>Volume</source>
         <extracomment>Label for a slider used to adjust audio notification volume
 ----------
@@ -418,8 +432,8 @@ Name of the slider used to adjust audio notification volume for accessibility te
         <translation>Glasnost</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="91"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="129"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="114"/>
         <source>Language</source>
         <extracomment>Label for combobox where users can specify the UI language
 ----------
@@ -427,12 +441,12 @@ Name of the combobox used to select UI langauge for accessibility tech like scre
         <translation type="unfinished">Jezik</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="117"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="102"/>
         <source>Restart Ricochet to apply changes</source>
         <translation type="unfinished">Za uveljavitev sprememb ponovno zaženite Ricochet</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="131"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="116"/>
         <source>What language ricochet will use</source>
         <extracomment>Description of what the language combox is for for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -507,17 +521,17 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="157"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="151"/>
         <source>Version Seperator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="191"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="185"/>
         <source>Remove %1</source>
         <translation>Odstrani  %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="192"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="186"/>
         <source>Do you want to permanently remove %1?</source>
         <translation>Ali želte za vselej odstraniti %1?</translation>
     </message>
@@ -549,79 +563,74 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>%1 ni povezan</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="169"/>
         <source>File transfer file name</source>
         <extracomment>Description of the text displaying the filename of a file transfer, used by accessibility tech like screen readres</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="195"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="185"/>
         <source>File transfer progress</source>
         <extracomment>Description of progress bar displaying the file transfer progress, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="210"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="200"/>
         <source>File transfer status</source>
         <extracomment>Description of label displaying the current status of a file transfer, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="225"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="215"/>
         <source>Download</source>
         <extracomment>Label for file transfer &apos;Download&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="227"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="217"/>
         <source>Download file</source>
         <extracomment>Description of what the file transfer &apos;Download&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="244"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="234"/>
         <source>Cancel or reject</source>
         <extracomment>Label for file transfer &apos;Cancel&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="246"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="236"/>
         <source>Cancels or rejects a file transfer</source>
         <extracomment>Description of what the file transfer &apos;Cancel&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="310"/>
         <source>Copy ID</source>
         <extracomment>Text for context menu command to copy a ricochet contact id to clipboard</extracomment>
-        <translation>Kopiraj ID</translation>
+        <translation type="vanished">Kopiraj ID</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="281"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="312"/>
         <source>Copy Link</source>
         <extracomment>Text for context menu command to copy a url to the clipboard</extracomment>
-        <translation>Kopiraj povezavo</translation>
+        <translation type="vanished">Kopiraj povezavo</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="287"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="318"/>
         <source>Open with Browser</source>
         <extracomment>Text for context menu command to open a url in a web browser</extracomment>
-        <translation>Odpri z brskalnikom</translation>
+        <translation type="vanished">Odpri z brskalnikom</translation>
     </message>
     <message>
         <source>Add as Contact</source>
         <translation type="vanished">Dodaj kot stik</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="335"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="262"/>
         <source>Copy Message</source>
         <extracomment>Text for context menu command to copy an entire message to clipboard</extracomment>
         <translation>Kopiraj sporočilo</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="343"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="270"/>
         <source>Copy Selection</source>
         <extracomment>Text for context menu command to copy selected text to clipboard</extracomment>
         <translation>Kopiraj izbor</translation>
@@ -705,38 +714,28 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>OpenBrowserDialog</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="41"/>
         <source>&lt;b&gt;Warning!&lt;/b&gt; Opening links with your default browser will harm your security and anonymity.&lt;br&gt;&lt;br&gt;You can &lt;a href=&apos;.&apos;&gt;copy to the clipboard&lt;/a&gt; instead.</source>
         <extracomment>Label displayed when user clicks on a link</extracomment>
-        <translation>&lt;b&gt;Pozor!&lt;/b&gt; Odpiranje povezav s privzetim brskalnikom škoduje vaši zasebnosti in varnosti.&lt;br&gt;&lt;br&gt;Lahko pa jih namesto tega&lt;a href=&apos;.&apos;&gt;prekopirate v odložišče&lt;/a&gt;.</translation>
+        <translation type="vanished">&lt;b&gt;Pozor!&lt;/b&gt; Odpiranje povezav s privzetim brskalnikom škoduje vaši zasebnosti in varnosti.&lt;br&gt;&lt;br&gt;Lahko pa jih namesto tega&lt;a href=&apos;.&apos;&gt;prekopirate v odložišče&lt;/a&gt;.</translation>
     </message>
     <message>
         <source>Don&apos;t ask again for links from %1</source>
         <translation type="vanished">Ne sprašuj več za povezavo z %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="50"/>
-        <source>Warning</source>
-        <extracomment>Name of warning label used with accessibility tech such as screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="65"/>
         <source>Don&apos;t ask again for any links (not recommended!)</source>
         <extracomment>Checkbox option text for when user clicks on a link</extracomment>
-        <translation>Ne sprašuj več za nobeno povezavo (ni priporočljivo!)</translation>
+        <translation type="vanished">Ne sprašuj več za nobeno povezavo (ni priporočljivo!)</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="73"/>
         <source>Open Browser</source>
         <extracomment>Label on button to open link in a web browser</extracomment>
-        <translation>Odpri brskalnik</translation>
+        <translation type="vanished">Odpri brskalnik</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="84"/>
         <source>Cancel</source>
         <extracomment>Label on cancel button</extracomment>
-        <translation>Prekliči</translation>
+        <translation type="vanished">Prekliči</translation>
     </message>
 </context>
 <context>
@@ -878,144 +877,144 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>Potrebuje ta računalnik proksi za dostop do medmrežja?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="69"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="70"/>
         <source>Proxy type:</source>
         <translation>Vrsta proksija:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="74"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="75"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="77"/>
         <source>None</source>
         <translation>Brez</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="92"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="93"/>
         <source>If you need a proxy to access the internet, select one from this list.</source>
         <extracomment>Description used by accessibility tech, such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="97"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="98"/>
         <source>Address:</source>
         <extracomment>Label indicating the textbox to place a proxy IP or URL</extracomment>
         <translation>Naslov</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="111"/>
         <source>IP address or hostname</source>
         <extracomment>Placeholder text of text box expecting an IP or URL for proxy</extracomment>
         <translation>Naslov IP ali ime gostitelja</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="115"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="116"/>
         <source>Enter the IP address or hostname of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the IP textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="119"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="120"/>
         <source>Port:</source>
         <extracomment>Label indicating the textbox to place a proxy port</extracomment>
         <translation>Vrata:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="130"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="131"/>
         <source>Port</source>
         <extracomment>Name of the port label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="132"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="133"/>
         <source>Enter the port of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the Port textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="138"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="139"/>
         <source>Username:</source>
         <extracomment>Label indicating the textbox to place the proxy username</extracomment>
         <translation>Uporabniško ime:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="152"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="173"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="153"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="174"/>
         <source>Optional</source>
         <extracomment>Textbox placeholder text indicating the field is not required</extracomment>
         <translation>Izbirno</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="156"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="157"/>
         <source>Username</source>
         <extracomment>Name of the username label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="158"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="159"/>
         <source>If required, enter the username for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Username textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="162"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="163"/>
         <source>Password:</source>
         <extracomment>Label indicating the textbox to place the proxy password</extracomment>
         <translation>Geslo:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="177"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="178"/>
         <source>Password</source>
         <extracomment>Name of the password label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="180"/>
         <source>If required, enter the password for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Password textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="190"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="191"/>
         <source>Does this computer&apos;s Internet connection go through a firewall that only allows connections to certain ports?</source>
         <extracomment>Description for the purpose of the Allowed Ports textbox</extracomment>
         <translation>Ali poteka povezava tega računalnika z medmrežjem čez požarni zid, ki dovoljuje povezavo le skozi določena vrata?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="211"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="212"/>
         <source>Allowed ports:</source>
         <extracomment>Label indicating the textbox to place the allowed ports</extracomment>
         <translation>Dovoljena vrata:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="220"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="221"/>
         <source>Example: 80,443</source>
         <extracomment>Textbox showing an example entry for the firewall allowed ports entry</extracomment>
         <translation>Primer: 80,443</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="224"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="225"/>
         <source>Allowed ports</source>
         <extracomment>Name of the allowed ports label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="236"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="237"/>
         <source>If this computer&apos;s Internet connection is censored, you will need to obtain and use bridge relays.</source>
         <translation>Če je povezava tega računalnika z medmrežjem cenzurirana, morate pridobiti posredniške mostove - bridge relays.</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="251"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="262"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="252"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="263"/>
         <source>Enter one or more bridge relays (one per line):</source>
         <translation>Vnesite enega ali več posredniških mostov (enega na vrstico):</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="273"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="274"/>
         <source>Back</source>
         <extracomment>Button label for going back to previous screen</extracomment>
         <translation>Nazaj</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="284"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="285"/>
         <source>Connect</source>
         <extracomment>Button label for connecting to tor</extracomment>
         <translation>Poveži se</translation>
@@ -1192,51 +1191,65 @@ Name of the button for launching the preferences window for accessibility tech l
     </message>
     <message>
         <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="114"/>
+        <source>Accepted</source>
+        <translation type="unfinished">Sprejeto</translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="115"/>
         <source>Rejected</source>
         <translation type="unfinished">Zavrnjeno</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="120"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
         <source>Cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
         <source>Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
         <source>Unkown Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
         <source>Bad File Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
         <source>Network Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="126"/>
         <source>File System Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="127"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="128"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="220"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="223"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="395"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="285"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="289"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="295"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="309"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="350"/>
+        <source>me</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="436"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/tego_ui/translation/ricochet_sq.ts
+++ b/src/tego_ui/translation/ricochet_sq.ts
@@ -21,29 +21,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="36"/>
-        <source>Ricochet Refresh web home page</source>
-        <extracomment>provides context for the URL for accessibility tech like screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="59"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="32"/>
         <source>The license of Ricochet Refresh and its dependencies</source>
-        <extracomment>summary of a block of text for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="60"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="33"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="65"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="37"/>
         <source>About</source>
         <translation type="unfinished">Mbi</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="39"/>
         <source>About page, contains license and version information</source>
         <extracomment>summary of the window&apos;s contents for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -105,37 +98,53 @@
 <context>
     <name>ContactActions</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="49"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <source>Could not successfully export conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="65"/>
         <source>Open Window</source>
         <extracomment>Context menu command to open the chat screen in a separate window</extracomment>
         <translation>Hap Dritare</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="70"/>
         <source>Details...</source>
         <extracomment>Context menu command to open a window showing the selected contact&apos;s details</extracomment>
         <translation>Hollësi…</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="56"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="75"/>
         <source>Rename</source>
         <extracomment>Context menu command to rename the selected contact</extracomment>
         <translation>Riemërtojeni</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="61"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="80"/>
         <source>Send File...</source>
         <extracomment>Context menu command to initiate a file transfer, opens a system file dialog</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="85"/>
+        <source>Export Conversation</source>
+        <extracomment>Context menu command to initiate a chat log export, opens a system file dialog to export to</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="91"/>
         <source>Remove</source>
         <extracomment>Context menu command to remove a contact from the contact list</extracomment>
         <translation>Hiqe</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="74"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="98"/>
         <source>Contact options</source>
         <extracomment>Description of the items in the context menu for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -151,30 +160,36 @@
     </message>
     <message>
         <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="45"/>
+        <source>This ID is invalid</source>
+        <extracomment>Error message showed when the id doesn&apos;t comply with spec https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
         <source>You can&apos;t add yourself as a contact</source>
         <extracomment>Error message showed when user attempts to add themselves as a contact in their contact list</extracomment>
         <translation>S’mund të shtoni veten si kontakt</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="55"/>
         <source>Enter an ID starting with &lt;b&gt;ricochet:&lt;/b&gt;</source>
         <extracomment>Error message showed when the provided ricochet id is invalid</extracomment>
         <translation>Jepni një ID që fillon me &lt;b&gt;ricochet:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="88"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="97"/>
         <source>Copied to clipboard</source>
         <extracomment>Message displayed when text is copied to the user&apos;s clipboard</extracomment>
         <translation>U kopjua në të papastër</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="103"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="112"/>
         <source>Copy</source>
         <extracomment>Text displayed on a button used to copy somethign to the user&apos;s clipboard</extracomment>
         <translation>Kopjoje</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="119"/>
         <source>Copies the ricochet id to the clipboard</source>
         <extracomment>Text description of ricochet id copy button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -397,20 +412,19 @@
         <translation>Përdor një dritare të vetme për bisedat</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Open links in default browser without prompting</source>
         <extracomment>Text description of an option to open URLs in default web browser when clicked</extracomment>
-        <translation>Hapi lidhjet në shfletuesin parazgjedhje, pa pyetur</translation>
+        <translation type="vanished">Hapi lidhjet në shfletuesin parazgjedhje, pa pyetur</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="44"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Play audio notifications</source>
         <extracomment>Text description of an option to play audio notifications when contacts log in, log out, and send messages</extracomment>
         <translation>Luaji njoftimet audion</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="61"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="77"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="62"/>
         <source>Volume</source>
         <extracomment>Label for a slider used to adjust audio notification volume
 ----------
@@ -418,8 +432,8 @@ Name of the slider used to adjust audio notification volume for accessibility te
         <translation>Volum</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="91"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="129"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="114"/>
         <source>Language</source>
         <extracomment>Label for combobox where users can specify the UI language
 ----------
@@ -427,12 +441,12 @@ Name of the combobox used to select UI langauge for accessibility tech like scre
         <translation type="unfinished">Gjuhë</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="117"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="102"/>
         <source>Restart Ricochet to apply changes</source>
         <translation type="unfinished">Riniseni Ricochet-in që të zbatohen ndryshimet</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="131"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="116"/>
         <source>What language ricochet will use</source>
         <extracomment>Description of what the language combox is for for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -507,17 +521,17 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="157"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="151"/>
         <source>Version Seperator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="191"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="185"/>
         <source>Remove %1</source>
         <translation>Hiqe</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="192"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="186"/>
         <source>Do you want to permanently remove %1?</source>
         <translation>Doni të hiqet %1 përgjithmonë?</translation>
     </message>
@@ -549,79 +563,74 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>%1 s’është në linjë</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="169"/>
         <source>File transfer file name</source>
         <extracomment>Description of the text displaying the filename of a file transfer, used by accessibility tech like screen readres</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="195"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="185"/>
         <source>File transfer progress</source>
         <extracomment>Description of progress bar displaying the file transfer progress, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="210"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="200"/>
         <source>File transfer status</source>
         <extracomment>Description of label displaying the current status of a file transfer, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="225"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="215"/>
         <source>Download</source>
         <extracomment>Label for file transfer &apos;Download&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="227"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="217"/>
         <source>Download file</source>
         <extracomment>Description of what the file transfer &apos;Download&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="244"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="234"/>
         <source>Cancel or reject</source>
         <extracomment>Label for file transfer &apos;Cancel&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="246"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="236"/>
         <source>Cancels or rejects a file transfer</source>
         <extracomment>Description of what the file transfer &apos;Cancel&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="310"/>
         <source>Copy ID</source>
         <extracomment>Text for context menu command to copy a ricochet contact id to clipboard</extracomment>
-        <translation>Kopjo ID-në</translation>
+        <translation type="vanished">Kopjo ID-në</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="281"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="312"/>
         <source>Copy Link</source>
         <extracomment>Text for context menu command to copy a url to the clipboard</extracomment>
-        <translation>Kopjo Lidhjen</translation>
+        <translation type="vanished">Kopjo Lidhjen</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="287"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="318"/>
         <source>Open with Browser</source>
         <extracomment>Text for context menu command to open a url in a web browser</extracomment>
-        <translation>Hape me Shfletues</translation>
+        <translation type="vanished">Hape me Shfletues</translation>
     </message>
     <message>
         <source>Add as Contact</source>
         <translation type="vanished">Shtojeni si Kontakt</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="335"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="262"/>
         <source>Copy Message</source>
         <extracomment>Text for context menu command to copy an entire message to clipboard</extracomment>
         <translation>Kopjo Mesazhin</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="343"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="270"/>
         <source>Copy Selection</source>
         <extracomment>Text for context menu command to copy selected text to clipboard</extracomment>
         <translation>Kopjo Përzgjedhjen</translation>
@@ -705,38 +714,28 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>OpenBrowserDialog</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="41"/>
         <source>&lt;b&gt;Warning!&lt;/b&gt; Opening links with your default browser will harm your security and anonymity.&lt;br&gt;&lt;br&gt;You can &lt;a href=&apos;.&apos;&gt;copy to the clipboard&lt;/a&gt; instead.</source>
         <extracomment>Label displayed when user clicks on a link</extracomment>
-        <translation>&lt;b&gt;Kujdes!&lt;/b&gt; Hapja e lidhjeve me shfletuesin tuaj parazgjedhje do të rrezikojë sigurinë dhe anonimitetin tuaj.&lt;br&gt;&lt;br&gt;Më mirë mund &lt;a href=&apos;.&apos;&gt;ta kopjoni në të papastër&lt;/a&gt;.</translation>
+        <translation type="vanished">&lt;b&gt;Kujdes!&lt;/b&gt; Hapja e lidhjeve me shfletuesin tuaj parazgjedhje do të rrezikojë sigurinë dhe anonimitetin tuaj.&lt;br&gt;&lt;br&gt;Më mirë mund &lt;a href=&apos;.&apos;&gt;ta kopjoni në të papastër&lt;/a&gt;.</translation>
     </message>
     <message>
         <source>Don&apos;t ask again for links from %1</source>
         <translation type="vanished">Mos pyet sërish për lidhje nga %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="50"/>
-        <source>Warning</source>
-        <extracomment>Name of warning label used with accessibility tech such as screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="65"/>
         <source>Don&apos;t ask again for any links (not recommended!)</source>
         <extracomment>Checkbox option text for when user clicks on a link</extracomment>
-        <translation>Mos pyet më, për çfarëdo lidhje (e pakëshillueshme!)</translation>
+        <translation type="vanished">Mos pyet më, për çfarëdo lidhje (e pakëshillueshme!)</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="73"/>
         <source>Open Browser</source>
         <extracomment>Label on button to open link in a web browser</extracomment>
-        <translation>Hap Shfletues</translation>
+        <translation type="vanished">Hap Shfletues</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="84"/>
         <source>Cancel</source>
         <extracomment>Label on cancel button</extracomment>
-        <translation>Anulojeni</translation>
+        <translation type="vanished">Anulojeni</translation>
     </message>
 </context>
 <context>
@@ -878,144 +877,144 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>Ka nevojë për ndërmjetës ky kompjuter, që të lidhet në internet?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="69"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="70"/>
         <source>Proxy type:</source>
         <translation>Lloj ndërmjetësi:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="74"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="75"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="77"/>
         <source>None</source>
         <translation>Asnjë</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="92"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="93"/>
         <source>If you need a proxy to access the internet, select one from this list.</source>
         <extracomment>Description used by accessibility tech, such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="97"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="98"/>
         <source>Address:</source>
         <extracomment>Label indicating the textbox to place a proxy IP or URL</extracomment>
         <translation>Adresë:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="111"/>
         <source>IP address or hostname</source>
         <extracomment>Placeholder text of text box expecting an IP or URL for proxy</extracomment>
         <translation>Adresë IP ose emër strehe</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="115"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="116"/>
         <source>Enter the IP address or hostname of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the IP textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="119"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="120"/>
         <source>Port:</source>
         <extracomment>Label indicating the textbox to place a proxy port</extracomment>
         <translation>Portë:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="130"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="131"/>
         <source>Port</source>
         <extracomment>Name of the port label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="132"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="133"/>
         <source>Enter the port of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the Port textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="138"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="139"/>
         <source>Username:</source>
         <extracomment>Label indicating the textbox to place the proxy username</extracomment>
         <translation>Emër përdoruesi:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="152"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="173"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="153"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="174"/>
         <source>Optional</source>
         <extracomment>Textbox placeholder text indicating the field is not required</extracomment>
         <translation>Opsionale</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="156"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="157"/>
         <source>Username</source>
         <extracomment>Name of the username label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="158"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="159"/>
         <source>If required, enter the username for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Username textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="162"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="163"/>
         <source>Password:</source>
         <extracomment>Label indicating the textbox to place the proxy password</extracomment>
         <translation>Fjalëkalim:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="177"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="178"/>
         <source>Password</source>
         <extracomment>Name of the password label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="180"/>
         <source>If required, enter the password for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Password textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="190"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="191"/>
         <source>Does this computer&apos;s Internet connection go through a firewall that only allows connections to certain ports?</source>
         <extracomment>Description for the purpose of the Allowed Ports textbox</extracomment>
         <translation>A kalon përmes një firewall-i lidhja internet e këtij kompjuteri, i cili lejon lidhje vetëm te disa prej portave?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="211"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="212"/>
         <source>Allowed ports:</source>
         <extracomment>Label indicating the textbox to place the allowed ports</extracomment>
         <translation>Porta të lejuara:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="220"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="221"/>
         <source>Example: 80,443</source>
         <extracomment>Textbox showing an example entry for the firewall allowed ports entry</extracomment>
         <translation>Shembull: 80,443</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="224"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="225"/>
         <source>Allowed ports</source>
         <extracomment>Name of the allowed ports label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="236"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="237"/>
         <source>If this computer&apos;s Internet connection is censored, you will need to obtain and use bridge relays.</source>
         <translation>Nëse lidhja në Internet e këtij kompjuteri është e censuruar, do t’ju duhet të merrni dhe përdorni &lt;i&gt;bridge relays&lt;/i&gt;.</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="251"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="262"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="252"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="263"/>
         <source>Enter one or more bridge relays (one per line):</source>
         <translation>Jepni një ose më tepër &lt;i&gt;bridge relays&lt;/i&gt; (një për rresht):</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="273"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="274"/>
         <source>Back</source>
         <extracomment>Button label for going back to previous screen</extracomment>
         <translation>Mbrapsht</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="284"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="285"/>
         <source>Connect</source>
         <extracomment>Button label for connecting to tor</extracomment>
         <translation>Lidhu</translation>
@@ -1192,51 +1191,65 @@ Name of the button for launching the preferences window for accessibility tech l
     </message>
     <message>
         <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="114"/>
+        <source>Accepted</source>
+        <translation type="unfinished">Të pranuara</translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="115"/>
         <source>Rejected</source>
         <translation type="unfinished">E hedhur tej</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="120"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
         <source>Cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
         <source>Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
         <source>Unkown Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
         <source>Bad File Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
         <source>Network Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="126"/>
         <source>File System Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="127"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="128"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="220"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="223"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="395"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="285"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="289"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="295"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="309"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="350"/>
+        <source>me</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="436"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/tego_ui/translation/ricochet_sv.ts
+++ b/src/tego_ui/translation/ricochet_sv.ts
@@ -21,29 +21,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="36"/>
-        <source>Ricochet Refresh web home page</source>
-        <extracomment>provides context for the URL for accessibility tech like screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="59"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="32"/>
         <source>The license of Ricochet Refresh and its dependencies</source>
-        <extracomment>summary of a block of text for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="60"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="33"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="65"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="37"/>
         <source>About</source>
         <translation type="unfinished">Om</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="39"/>
         <source>About page, contains license and version information</source>
         <extracomment>summary of the window&apos;s contents for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -105,37 +98,53 @@
 <context>
     <name>ContactActions</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="49"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <source>Could not successfully export conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="65"/>
         <source>Open Window</source>
         <extracomment>Context menu command to open the chat screen in a separate window</extracomment>
         <translation>Öppna fönster</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="70"/>
         <source>Details...</source>
         <extracomment>Context menu command to open a window showing the selected contact&apos;s details</extracomment>
         <translation>Detaljer...</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="56"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="75"/>
         <source>Rename</source>
         <extracomment>Context menu command to rename the selected contact</extracomment>
         <translation>Ändra namn</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="61"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="80"/>
         <source>Send File...</source>
         <extracomment>Context menu command to initiate a file transfer, opens a system file dialog</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="85"/>
+        <source>Export Conversation</source>
+        <extracomment>Context menu command to initiate a chat log export, opens a system file dialog to export to</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="91"/>
         <source>Remove</source>
         <extracomment>Context menu command to remove a contact from the contact list</extracomment>
         <translation>Ta bort</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="74"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="98"/>
         <source>Contact options</source>
         <extracomment>Description of the items in the context menu for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -151,30 +160,36 @@
     </message>
     <message>
         <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="45"/>
+        <source>This ID is invalid</source>
+        <extracomment>Error message showed when the id doesn&apos;t comply with spec https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
         <source>You can&apos;t add yourself as a contact</source>
         <extracomment>Error message showed when user attempts to add themselves as a contact in their contact list</extracomment>
         <translation>Du kan inte lägga till dig själv som kontakt</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="55"/>
         <source>Enter an ID starting with &lt;b&gt;ricochet:&lt;/b&gt;</source>
         <extracomment>Error message showed when the provided ricochet id is invalid</extracomment>
         <translation>Fyll i ett ID som startar med &lt;b&gt;ricochet:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="88"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="97"/>
         <source>Copied to clipboard</source>
         <extracomment>Message displayed when text is copied to the user&apos;s clipboard</extracomment>
         <translation>Kopierat till Urklipp</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="103"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="112"/>
         <source>Copy</source>
         <extracomment>Text displayed on a button used to copy somethign to the user&apos;s clipboard</extracomment>
         <translation>Kopiera</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="119"/>
         <source>Copies the ricochet id to the clipboard</source>
         <extracomment>Text description of ricochet id copy button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -397,20 +412,19 @@
         <translation>Använd bara ett fönster för konversationer</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Open links in default browser without prompting</source>
         <extracomment>Text description of an option to open URLs in default web browser when clicked</extracomment>
-        <translation>Öppna länkar i standardwebbläsaren utan att fråga</translation>
+        <translation type="vanished">Öppna länkar i standardwebbläsaren utan att fråga</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="44"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Play audio notifications</source>
         <extracomment>Text description of an option to play audio notifications when contacts log in, log out, and send messages</extracomment>
         <translation>Spela ljudnotiser</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="61"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="77"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="62"/>
         <source>Volume</source>
         <extracomment>Label for a slider used to adjust audio notification volume
 ----------
@@ -418,8 +432,8 @@ Name of the slider used to adjust audio notification volume for accessibility te
         <translation>Volym</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="91"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="129"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="114"/>
         <source>Language</source>
         <extracomment>Label for combobox where users can specify the UI language
 ----------
@@ -427,12 +441,12 @@ Name of the combobox used to select UI langauge for accessibility tech like scre
         <translation type="unfinished">Språk</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="117"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="102"/>
         <source>Restart Ricochet to apply changes</source>
         <translation type="unfinished">Starta om Ricochet för att aktivera ändringarna</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="131"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="116"/>
         <source>What language ricochet will use</source>
         <extracomment>Description of what the language combox is for for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -507,17 +521,17 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="157"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="151"/>
         <source>Version Seperator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="191"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="185"/>
         <source>Remove %1</source>
         <translation>Ta bort %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="192"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="186"/>
         <source>Do you want to permanently remove %1?</source>
         <translation>Vill du ta bort %1 permanent?</translation>
     </message>
@@ -549,79 +563,74 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>%1 är offline</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="169"/>
         <source>File transfer file name</source>
         <extracomment>Description of the text displaying the filename of a file transfer, used by accessibility tech like screen readres</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="195"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="185"/>
         <source>File transfer progress</source>
         <extracomment>Description of progress bar displaying the file transfer progress, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="210"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="200"/>
         <source>File transfer status</source>
         <extracomment>Description of label displaying the current status of a file transfer, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="225"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="215"/>
         <source>Download</source>
         <extracomment>Label for file transfer &apos;Download&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="227"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="217"/>
         <source>Download file</source>
         <extracomment>Description of what the file transfer &apos;Download&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="244"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="234"/>
         <source>Cancel or reject</source>
         <extracomment>Label for file transfer &apos;Cancel&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="246"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="236"/>
         <source>Cancels or rejects a file transfer</source>
         <extracomment>Description of what the file transfer &apos;Cancel&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="310"/>
         <source>Copy ID</source>
         <extracomment>Text for context menu command to copy a ricochet contact id to clipboard</extracomment>
-        <translation>Kopiera ID</translation>
+        <translation type="vanished">Kopiera ID</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="281"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="312"/>
         <source>Copy Link</source>
         <extracomment>Text for context menu command to copy a url to the clipboard</extracomment>
-        <translation>Kopiera länk</translation>
+        <translation type="vanished">Kopiera länk</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="287"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="318"/>
         <source>Open with Browser</source>
         <extracomment>Text for context menu command to open a url in a web browser</extracomment>
-        <translation>Öppna med webbläsare</translation>
+        <translation type="vanished">Öppna med webbläsare</translation>
     </message>
     <message>
         <source>Add as Contact</source>
         <translation type="vanished">Lägg till som kontakt</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="335"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="262"/>
         <source>Copy Message</source>
         <extracomment>Text for context menu command to copy an entire message to clipboard</extracomment>
         <translation>Kopiera meddelande</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="343"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="270"/>
         <source>Copy Selection</source>
         <extracomment>Text for context menu command to copy selected text to clipboard</extracomment>
         <translation>Kopiera markering</translation>
@@ -705,38 +714,28 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>OpenBrowserDialog</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="41"/>
         <source>&lt;b&gt;Warning!&lt;/b&gt; Opening links with your default browser will harm your security and anonymity.&lt;br&gt;&lt;br&gt;You can &lt;a href=&apos;.&apos;&gt;copy to the clipboard&lt;/a&gt; instead.</source>
         <extracomment>Label displayed when user clicks on a link</extracomment>
-        <translation>&lt;b&gt;Varning!&lt;/b&gt; Att öppna länkar med din standard&amp;shy;webbläsare skadar din säkerhet och anonymitet.&lt;br&gt;&lt;br&gt;Du kan &lt;a href=&apos;.&apos;&gt;kopiera till Urklipp&lt;/a&gt; istället.</translation>
+        <translation type="vanished">&lt;b&gt;Varning!&lt;/b&gt; Att öppna länkar med din standard&amp;shy;webbläsare skadar din säkerhet och anonymitet.&lt;br&gt;&lt;br&gt;Du kan &lt;a href=&apos;.&apos;&gt;kopiera till Urklipp&lt;/a&gt; istället.</translation>
     </message>
     <message>
         <source>Don&apos;t ask again for links from %1</source>
         <translation type="vanished">Fråga inte igen för länkar från %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="50"/>
-        <source>Warning</source>
-        <extracomment>Name of warning label used with accessibility tech such as screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="65"/>
         <source>Don&apos;t ask again for any links (not recommended!)</source>
         <extracomment>Checkbox option text for when user clicks on a link</extracomment>
-        <translation>Fråga inte igen för några länkar (rekommenderas inte!)</translation>
+        <translation type="vanished">Fråga inte igen för några länkar (rekommenderas inte!)</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="73"/>
         <source>Open Browser</source>
         <extracomment>Label on button to open link in a web browser</extracomment>
-        <translation>Öppna webbläsaren</translation>
+        <translation type="vanished">Öppna webbläsaren</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="84"/>
         <source>Cancel</source>
         <extracomment>Label on cancel button</extracomment>
-        <translation>Avbryt</translation>
+        <translation type="vanished">Avbryt</translation>
     </message>
 </context>
 <context>
@@ -878,144 +877,144 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>Behöver den här datorn använda en proxy för att ansluta till Internet?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="69"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="70"/>
         <source>Proxy type:</source>
         <translation>Typ av proxy:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="74"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="75"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="77"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="92"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="93"/>
         <source>If you need a proxy to access the internet, select one from this list.</source>
         <extracomment>Description used by accessibility tech, such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="97"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="98"/>
         <source>Address:</source>
         <extracomment>Label indicating the textbox to place a proxy IP or URL</extracomment>
         <translation>Adress:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="111"/>
         <source>IP address or hostname</source>
         <extracomment>Placeholder text of text box expecting an IP or URL for proxy</extracomment>
         <translation>IP-adress eller värdnamn</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="115"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="116"/>
         <source>Enter the IP address or hostname of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the IP textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="119"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="120"/>
         <source>Port:</source>
         <extracomment>Label indicating the textbox to place a proxy port</extracomment>
         <translation>Port:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="130"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="131"/>
         <source>Port</source>
         <extracomment>Name of the port label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="132"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="133"/>
         <source>Enter the port of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the Port textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="138"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="139"/>
         <source>Username:</source>
         <extracomment>Label indicating the textbox to place the proxy username</extracomment>
         <translation>Användarnamn:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="152"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="173"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="153"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="174"/>
         <source>Optional</source>
         <extracomment>Textbox placeholder text indicating the field is not required</extracomment>
         <translation>Krävs ej</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="156"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="157"/>
         <source>Username</source>
         <extracomment>Name of the username label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="158"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="159"/>
         <source>If required, enter the username for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Username textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="162"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="163"/>
         <source>Password:</source>
         <extracomment>Label indicating the textbox to place the proxy password</extracomment>
         <translation>Lösenord:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="177"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="178"/>
         <source>Password</source>
         <extracomment>Name of the password label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="180"/>
         <source>If required, enter the password for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Password textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="190"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="191"/>
         <source>Does this computer&apos;s Internet connection go through a firewall that only allows connections to certain ports?</source>
         <extracomment>Description for the purpose of the Allowed Ports textbox</extracomment>
         <translation>Går den här datorns Internetanslutning genom en brandvägg som bara tillåter anslutningar på vissa portar?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="211"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="212"/>
         <source>Allowed ports:</source>
         <extracomment>Label indicating the textbox to place the allowed ports</extracomment>
         <translation>Tillåtna portar:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="220"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="221"/>
         <source>Example: 80,443</source>
         <extracomment>Textbox showing an example entry for the firewall allowed ports entry</extracomment>
         <translation>Exempel: 80,443</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="224"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="225"/>
         <source>Allowed ports</source>
         <extracomment>Name of the allowed ports label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="236"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="237"/>
         <source>If this computer&apos;s Internet connection is censored, you will need to obtain and use bridge relays.</source>
         <translation>Om den här datorns Internetanslutning är censurerad måste du skaffa och använda en brygga till Tor, en så kallad ”bridge relay”.</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="251"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="262"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="252"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="263"/>
         <source>Enter one or more bridge relays (one per line):</source>
         <translation>Ange en eller flera bryggor (en per rad):</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="273"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="274"/>
         <source>Back</source>
         <extracomment>Button label for going back to previous screen</extracomment>
         <translation>Tillbaka</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="284"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="285"/>
         <source>Connect</source>
         <extracomment>Button label for connecting to tor</extracomment>
         <translation>Anslut</translation>
@@ -1192,51 +1191,65 @@ Name of the button for launching the preferences window for accessibility tech l
     </message>
     <message>
         <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="114"/>
+        <source>Accepted</source>
+        <translation type="unfinished">Godkänd</translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="115"/>
         <source>Rejected</source>
         <translation type="unfinished">Nekad</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="120"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
         <source>Cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
         <source>Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
         <source>Unkown Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
         <source>Bad File Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
         <source>Network Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="126"/>
         <source>File System Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="127"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="128"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="220"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="223"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="395"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="285"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="289"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="295"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="309"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="350"/>
+        <source>me</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="436"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/tego_ui/translation/ricochet_tr.ts
+++ b/src/tego_ui/translation/ricochet_tr.ts
@@ -21,29 +21,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="36"/>
-        <source>Ricochet Refresh web home page</source>
-        <extracomment>provides context for the URL for accessibility tech like screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="59"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="32"/>
         <source>The license of Ricochet Refresh and its dependencies</source>
-        <extracomment>summary of a block of text for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="60"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="33"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="65"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="37"/>
         <source>About</source>
         <translation type="unfinished">Hakkında</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="39"/>
         <source>About page, contains license and version information</source>
         <extracomment>summary of the window&apos;s contents for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -105,37 +98,53 @@
 <context>
     <name>ContactActions</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="49"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <source>Could not successfully export conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="65"/>
         <source>Open Window</source>
         <extracomment>Context menu command to open the chat screen in a separate window</extracomment>
         <translation>Yeni Pencere</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="70"/>
         <source>Details...</source>
         <extracomment>Context menu command to open a window showing the selected contact&apos;s details</extracomment>
         <translation>Ayrıntılar...</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="56"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="75"/>
         <source>Rename</source>
         <extracomment>Context menu command to rename the selected contact</extracomment>
         <translation>Yeniden adlandır</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="61"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="80"/>
         <source>Send File...</source>
         <extracomment>Context menu command to initiate a file transfer, opens a system file dialog</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="85"/>
+        <source>Export Conversation</source>
+        <extracomment>Context menu command to initiate a chat log export, opens a system file dialog to export to</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="91"/>
         <source>Remove</source>
         <extracomment>Context menu command to remove a contact from the contact list</extracomment>
         <translation>Çıkar</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="74"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="98"/>
         <source>Contact options</source>
         <extracomment>Description of the items in the context menu for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -151,30 +160,36 @@
     </message>
     <message>
         <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="45"/>
+        <source>This ID is invalid</source>
+        <extracomment>Error message showed when the id doesn&apos;t comply with spec https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
         <source>You can&apos;t add yourself as a contact</source>
         <extracomment>Error message showed when user attempts to add themselves as a contact in their contact list</extracomment>
         <translation>Kendinizi kişi listesine ekleyemezsiniz</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="55"/>
         <source>Enter an ID starting with &lt;b&gt;ricochet:&lt;/b&gt;</source>
         <extracomment>Error message showed when the provided ricochet id is invalid</extracomment>
         <translation>&lt;b&gt;ricochet:&lt;/b&gt; ile başlayan bir kimlik girin</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="88"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="97"/>
         <source>Copied to clipboard</source>
         <extracomment>Message displayed when text is copied to the user&apos;s clipboard</extracomment>
         <translation>Panoya kopyalandı</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="103"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="112"/>
         <source>Copy</source>
         <extracomment>Text displayed on a button used to copy somethign to the user&apos;s clipboard</extracomment>
         <translation>Kopyala</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="119"/>
         <source>Copies the ricochet id to the clipboard</source>
         <extracomment>Text description of ricochet id copy button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -397,20 +412,19 @@
         <translation>Görüşmeler için tek pencere kullan</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Open links in default browser without prompting</source>
         <extracomment>Text description of an option to open URLs in default web browser when clicked</extracomment>
-        <translation>Bağlantıları bana sormadan varsayılan tarayıcıda aç</translation>
+        <translation type="vanished">Bağlantıları bana sormadan varsayılan tarayıcıda aç</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="44"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Play audio notifications</source>
         <extracomment>Text description of an option to play audio notifications when contacts log in, log out, and send messages</extracomment>
         <translation>Ses bildirimlerini oynat</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="61"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="77"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="62"/>
         <source>Volume</source>
         <extracomment>Label for a slider used to adjust audio notification volume
 ----------
@@ -418,8 +432,8 @@ Name of the slider used to adjust audio notification volume for accessibility te
         <translation>Ses</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="91"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="129"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="114"/>
         <source>Language</source>
         <extracomment>Label for combobox where users can specify the UI language
 ----------
@@ -427,12 +441,12 @@ Name of the combobox used to select UI langauge for accessibility tech like scre
         <translation type="unfinished">Dil</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="117"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="102"/>
         <source>Restart Ricochet to apply changes</source>
         <translation type="unfinished">Değişikliklerin uygulanması için Ricochet&apos;i yeniden başlatın.</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="131"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="116"/>
         <source>What language ricochet will use</source>
         <extracomment>Description of what the language combox is for for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -507,17 +521,17 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="157"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="151"/>
         <source>Version Seperator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="191"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="185"/>
         <source>Remove %1</source>
         <translation>%1 isimli kullanıcıyı kişi listesinden çıkar</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="192"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="186"/>
         <source>Do you want to permanently remove %1?</source>
         <translation>%1 isimli kullanıcıyı kalıcı olarak silmek istiyor musunuz?</translation>
     </message>
@@ -549,79 +563,74 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>%1 çevrimdışı</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="169"/>
         <source>File transfer file name</source>
         <extracomment>Description of the text displaying the filename of a file transfer, used by accessibility tech like screen readres</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="195"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="185"/>
         <source>File transfer progress</source>
         <extracomment>Description of progress bar displaying the file transfer progress, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="210"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="200"/>
         <source>File transfer status</source>
         <extracomment>Description of label displaying the current status of a file transfer, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="225"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="215"/>
         <source>Download</source>
         <extracomment>Label for file transfer &apos;Download&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="227"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="217"/>
         <source>Download file</source>
         <extracomment>Description of what the file transfer &apos;Download&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="244"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="234"/>
         <source>Cancel or reject</source>
         <extracomment>Label for file transfer &apos;Cancel&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="246"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="236"/>
         <source>Cancels or rejects a file transfer</source>
         <extracomment>Description of what the file transfer &apos;Cancel&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="310"/>
         <source>Copy ID</source>
         <extracomment>Text for context menu command to copy a ricochet contact id to clipboard</extracomment>
-        <translation>Kimliği kopyala</translation>
+        <translation type="vanished">Kimliği kopyala</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="281"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="312"/>
         <source>Copy Link</source>
         <extracomment>Text for context menu command to copy a url to the clipboard</extracomment>
-        <translation>Bağlantı Kopyala</translation>
+        <translation type="vanished">Bağlantı Kopyala</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="287"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="318"/>
         <source>Open with Browser</source>
         <extracomment>Text for context menu command to open a url in a web browser</extracomment>
-        <translation>Tarayıcı ile Aç</translation>
+        <translation type="vanished">Tarayıcı ile Aç</translation>
     </message>
     <message>
         <source>Add as Contact</source>
         <translation type="vanished">Kişi olarak Ekle</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="335"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="262"/>
         <source>Copy Message</source>
         <extracomment>Text for context menu command to copy an entire message to clipboard</extracomment>
         <translation>Mesajı Kopyala</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="343"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="270"/>
         <source>Copy Selection</source>
         <extracomment>Text for context menu command to copy selected text to clipboard</extracomment>
         <translation>Seçileni Kopyala</translation>
@@ -705,38 +714,28 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>OpenBrowserDialog</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="41"/>
         <source>&lt;b&gt;Warning!&lt;/b&gt; Opening links with your default browser will harm your security and anonymity.&lt;br&gt;&lt;br&gt;You can &lt;a href=&apos;.&apos;&gt;copy to the clipboard&lt;/a&gt; instead.</source>
         <extracomment>Label displayed when user clicks on a link</extracomment>
-        <translation>&lt;b&gt;Uyarı!&lt;/b&gt; Varsayılan tarayıcı ile bağlantıları açmak, güvenlik ve anonimliğinize zarar verecektir.&lt;br&gt;&lt;br&gt;Bunun yerine &lt;a href=&apos;.&apos;&gt;panoya kopyala&lt;/a&gt;yabilirsiniz.</translation>
+        <translation type="vanished">&lt;b&gt;Uyarı!&lt;/b&gt; Varsayılan tarayıcı ile bağlantıları açmak, güvenlik ve anonimliğinize zarar verecektir.&lt;br&gt;&lt;br&gt;Bunun yerine &lt;a href=&apos;.&apos;&gt;panoya kopyala&lt;/a&gt;yabilirsiniz.</translation>
     </message>
     <message>
         <source>Don&apos;t ask again for links from %1</source>
         <translation type="vanished">%1 isimli kullanıcıdan gelen bağlantılar için tekrar sorma</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="50"/>
-        <source>Warning</source>
-        <extracomment>Name of warning label used with accessibility tech such as screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="65"/>
         <source>Don&apos;t ask again for any links (not recommended!)</source>
         <extracomment>Checkbox option text for when user clicks on a link</extracomment>
-        <translation>Bundan sonra bağlantılar için bir daha sorma (tavsiye edilmez!)</translation>
+        <translation type="vanished">Bundan sonra bağlantılar için bir daha sorma (tavsiye edilmez!)</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="73"/>
         <source>Open Browser</source>
         <extracomment>Label on button to open link in a web browser</extracomment>
-        <translation>Tarayıcıyı Aç</translation>
+        <translation type="vanished">Tarayıcıyı Aç</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="84"/>
         <source>Cancel</source>
         <extracomment>Label on cancel button</extracomment>
-        <translation>İptal</translation>
+        <translation type="vanished">İptal</translation>
     </message>
 </context>
 <context>
@@ -878,144 +877,144 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>Bu bilgisayar internete erişmek için bir proxy&apos;e ihtiyaç duyuyor mu?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="69"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="70"/>
         <source>Proxy type:</source>
         <translation>Proxy türü:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="74"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="75"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="77"/>
         <source>None</source>
         <translation>Hiçbiri</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="92"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="93"/>
         <source>If you need a proxy to access the internet, select one from this list.</source>
         <extracomment>Description used by accessibility tech, such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="97"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="98"/>
         <source>Address:</source>
         <extracomment>Label indicating the textbox to place a proxy IP or URL</extracomment>
         <translation>Adres:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="111"/>
         <source>IP address or hostname</source>
         <extracomment>Placeholder text of text box expecting an IP or URL for proxy</extracomment>
         <translation>IP adresi veya host adı</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="115"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="116"/>
         <source>Enter the IP address or hostname of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the IP textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="119"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="120"/>
         <source>Port:</source>
         <extracomment>Label indicating the textbox to place a proxy port</extracomment>
         <translation>Port:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="130"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="131"/>
         <source>Port</source>
         <extracomment>Name of the port label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="132"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="133"/>
         <source>Enter the port of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the Port textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="138"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="139"/>
         <source>Username:</source>
         <extracomment>Label indicating the textbox to place the proxy username</extracomment>
         <translation>Kullanıcı adı:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="152"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="173"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="153"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="174"/>
         <source>Optional</source>
         <extracomment>Textbox placeholder text indicating the field is not required</extracomment>
         <translation>İsteğe bağlı</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="156"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="157"/>
         <source>Username</source>
         <extracomment>Name of the username label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="158"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="159"/>
         <source>If required, enter the username for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Username textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="162"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="163"/>
         <source>Password:</source>
         <extracomment>Label indicating the textbox to place the proxy password</extracomment>
         <translation>Parola:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="177"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="178"/>
         <source>Password</source>
         <extracomment>Name of the password label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="180"/>
         <source>If required, enter the password for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Password textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="190"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="191"/>
         <source>Does this computer&apos;s Internet connection go through a firewall that only allows connections to certain ports?</source>
         <extracomment>Description for the purpose of the Allowed Ports textbox</extracomment>
         <translation>Bu bilgisayarın internet bağlantısı sadece belli portlara bağlantı izni veren bir güvenlik duvarı üzerinden gidiyor mu?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="211"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="212"/>
         <source>Allowed ports:</source>
         <extracomment>Label indicating the textbox to place the allowed ports</extracomment>
         <translation>İzin verilen portlar:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="220"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="221"/>
         <source>Example: 80,443</source>
         <extracomment>Textbox showing an example entry for the firewall allowed ports entry</extracomment>
         <translation>Örnek: 80.443</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="224"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="225"/>
         <source>Allowed ports</source>
         <extracomment>Name of the allowed ports label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="236"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="237"/>
         <source>If this computer&apos;s Internet connection is censored, you will need to obtain and use bridge relays.</source>
         <translation>Bu bilgisayarın internet bağlantısı sansürlenmişse, köprü aktarımlarını edinmeniz ve kullanmanız gerekir.</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="251"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="262"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="252"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="263"/>
         <source>Enter one or more bridge relays (one per line):</source>
         <translation>Bir veya birden fazla köprü aktarım adresi girin (satır başına bir tane):</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="273"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="274"/>
         <source>Back</source>
         <extracomment>Button label for going back to previous screen</extracomment>
         <translation>Geri</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="284"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="285"/>
         <source>Connect</source>
         <extracomment>Button label for connecting to tor</extracomment>
         <translation>Bağlan</translation>
@@ -1192,51 +1191,65 @@ Name of the button for launching the preferences window for accessibility tech l
     </message>
     <message>
         <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="114"/>
+        <source>Accepted</source>
+        <translation type="unfinished">Kabul edildi</translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="115"/>
         <source>Rejected</source>
         <translation type="unfinished">Reddedildi</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="120"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
         <source>Cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
         <source>Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
         <source>Unkown Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
         <source>Bad File Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
         <source>Network Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="126"/>
         <source>File System Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="127"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="128"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="220"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="223"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="395"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="285"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="289"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="295"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="309"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="350"/>
+        <source>me</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="436"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/tego_ui/translation/ricochet_uk.ts
+++ b/src/tego_ui/translation/ricochet_uk.ts
@@ -21,29 +21,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="36"/>
-        <source>Ricochet Refresh web home page</source>
-        <extracomment>provides context for the URL for accessibility tech like screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="59"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="32"/>
         <source>The license of Ricochet Refresh and its dependencies</source>
-        <extracomment>summary of a block of text for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="60"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="33"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="65"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="37"/>
         <source>About</source>
         <translation type="unfinished">Про </translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="39"/>
         <source>About page, contains license and version information</source>
         <extracomment>summary of the window&apos;s contents for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -105,37 +98,53 @@
 <context>
     <name>ContactActions</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="49"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <source>Could not successfully export conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="65"/>
         <source>Open Window</source>
         <extracomment>Context menu command to open the chat screen in a separate window</extracomment>
         <translation>Відкрити вікно</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="70"/>
         <source>Details...</source>
         <extracomment>Context menu command to open a window showing the selected contact&apos;s details</extracomment>
         <translation>Детальніше...</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="56"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="75"/>
         <source>Rename</source>
         <extracomment>Context menu command to rename the selected contact</extracomment>
         <translation>Перейменувати</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="61"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="80"/>
         <source>Send File...</source>
         <extracomment>Context menu command to initiate a file transfer, opens a system file dialog</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="85"/>
+        <source>Export Conversation</source>
+        <extracomment>Context menu command to initiate a chat log export, opens a system file dialog to export to</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="91"/>
         <source>Remove</source>
         <extracomment>Context menu command to remove a contact from the contact list</extracomment>
         <translation>Видалити</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="74"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="98"/>
         <source>Contact options</source>
         <extracomment>Description of the items in the context menu for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -151,30 +160,36 @@
     </message>
     <message>
         <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="45"/>
+        <source>This ID is invalid</source>
+        <extracomment>Error message showed when the id doesn&apos;t comply with spec https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
         <source>You can&apos;t add yourself as a contact</source>
         <extracomment>Error message showed when user attempts to add themselves as a contact in their contact list</extracomment>
         <translation>Ви не можете додати самі себе як контакт</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="55"/>
         <source>Enter an ID starting with &lt;b&gt;ricochet:&lt;/b&gt;</source>
         <extracomment>Error message showed when the provided ricochet id is invalid</extracomment>
         <translation>Введіть ID який починається з &lt;b&gt;ricochet:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="88"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="97"/>
         <source>Copied to clipboard</source>
         <extracomment>Message displayed when text is copied to the user&apos;s clipboard</extracomment>
         <translation>Скопійовано до  буферу обміну</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="103"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="112"/>
         <source>Copy</source>
         <extracomment>Text displayed on a button used to copy somethign to the user&apos;s clipboard</extracomment>
         <translation>Копіювати</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="119"/>
         <source>Copies the ricochet id to the clipboard</source>
         <extracomment>Text description of ricochet id copy button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -397,20 +412,19 @@
         <translation>Використовувати одне вікно для розмов</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Open links in default browser without prompting</source>
         <extracomment>Text description of an option to open URLs in default web browser when clicked</extracomment>
-        <translation>Відкривати посилання в браузері без запитань</translation>
+        <translation type="vanished">Відкривати посилання в браузері без запитань</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="44"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Play audio notifications</source>
         <extracomment>Text description of an option to play audio notifications when contacts log in, log out, and send messages</extracomment>
         <translation>Програти аудіо повідомлення</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="61"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="77"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="62"/>
         <source>Volume</source>
         <extracomment>Label for a slider used to adjust audio notification volume
 ----------
@@ -418,8 +432,8 @@ Name of the slider used to adjust audio notification volume for accessibility te
         <translation>Гучність</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="91"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="129"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="114"/>
         <source>Language</source>
         <extracomment>Label for combobox where users can specify the UI language
 ----------
@@ -427,12 +441,12 @@ Name of the combobox used to select UI langauge for accessibility tech like scre
         <translation type="unfinished">Мова</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="117"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="102"/>
         <source>Restart Ricochet to apply changes</source>
         <translation type="unfinished">Перезавантажити Ricochet для збереження змін</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="131"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="116"/>
         <source>What language ricochet will use</source>
         <extracomment>Description of what the language combox is for for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -507,17 +521,17 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="157"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="151"/>
         <source>Version Seperator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="191"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="185"/>
         <source>Remove %1</source>
         <translation>Видалити %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="192"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="186"/>
         <source>Do you want to permanently remove %1?</source>
         <translation>Бажаєте назавжди видалити %1?</translation>
     </message>
@@ -549,79 +563,74 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>%1 не в мережі</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="169"/>
         <source>File transfer file name</source>
         <extracomment>Description of the text displaying the filename of a file transfer, used by accessibility tech like screen readres</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="195"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="185"/>
         <source>File transfer progress</source>
         <extracomment>Description of progress bar displaying the file transfer progress, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="210"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="200"/>
         <source>File transfer status</source>
         <extracomment>Description of label displaying the current status of a file transfer, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="225"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="215"/>
         <source>Download</source>
         <extracomment>Label for file transfer &apos;Download&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="227"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="217"/>
         <source>Download file</source>
         <extracomment>Description of what the file transfer &apos;Download&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="244"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="234"/>
         <source>Cancel or reject</source>
         <extracomment>Label for file transfer &apos;Cancel&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="246"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="236"/>
         <source>Cancels or rejects a file transfer</source>
         <extracomment>Description of what the file transfer &apos;Cancel&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="310"/>
         <source>Copy ID</source>
         <extracomment>Text for context menu command to copy a ricochet contact id to clipboard</extracomment>
-        <translation>Копіювати ID</translation>
+        <translation type="vanished">Копіювати ID</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="281"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="312"/>
         <source>Copy Link</source>
         <extracomment>Text for context menu command to copy a url to the clipboard</extracomment>
-        <translation>Копіювати посилання</translation>
+        <translation type="vanished">Копіювати посилання</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="287"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="318"/>
         <source>Open with Browser</source>
         <extracomment>Text for context menu command to open a url in a web browser</extracomment>
-        <translation>Відкрити браузер</translation>
+        <translation type="vanished">Відкрити браузер</translation>
     </message>
     <message>
         <source>Add as Contact</source>
         <translation type="vanished">Додати як контакт</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="335"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="262"/>
         <source>Copy Message</source>
         <extracomment>Text for context menu command to copy an entire message to clipboard</extracomment>
         <translation>Скопіювати повідомлення</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="343"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="270"/>
         <source>Copy Selection</source>
         <extracomment>Text for context menu command to copy selected text to clipboard</extracomment>
         <translation>Скопіювати вибране</translation>
@@ -705,38 +714,28 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>OpenBrowserDialog</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="41"/>
         <source>&lt;b&gt;Warning!&lt;/b&gt; Opening links with your default browser will harm your security and anonymity.&lt;br&gt;&lt;br&gt;You can &lt;a href=&apos;.&apos;&gt;copy to the clipboard&lt;/a&gt; instead.</source>
         <extracomment>Label displayed when user clicks on a link</extracomment>
-        <translation>&lt;b&gt;Попередження!&lt;/b&gt; Відкриття посилань у браузері за замовчуванням може нашкодити вашій безпеці та анонімності. &lt;br&gt;&lt;br&gt;Замість цього ви можете їх &lt;a href=&apos;.&apos;&gt;скопіювати у буфер обміну&lt;/a&gt; .</translation>
+        <translation type="vanished">&lt;b&gt;Попередження!&lt;/b&gt; Відкриття посилань у браузері за замовчуванням може нашкодити вашій безпеці та анонімності. &lt;br&gt;&lt;br&gt;Замість цього ви можете їх &lt;a href=&apos;.&apos;&gt;скопіювати у буфер обміну&lt;/a&gt; .</translation>
     </message>
     <message>
         <source>Don&apos;t ask again for links from %1</source>
         <translation type="vanished">Не запитувати знову про посилання від %1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="50"/>
-        <source>Warning</source>
-        <extracomment>Name of warning label used with accessibility tech such as screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="65"/>
         <source>Don&apos;t ask again for any links (not recommended!)</source>
         <extracomment>Checkbox option text for when user clicks on a link</extracomment>
-        <translation>Не запитувати знову про будь-які посилання (не рекомендовано!)</translation>
+        <translation type="vanished">Не запитувати знову про будь-які посилання (не рекомендовано!)</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="73"/>
         <source>Open Browser</source>
         <extracomment>Label on button to open link in a web browser</extracomment>
-        <translation>Відкрити браузер</translation>
+        <translation type="vanished">Відкрити браузер</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="84"/>
         <source>Cancel</source>
         <extracomment>Label on cancel button</extracomment>
-        <translation>Відмінити</translation>
+        <translation type="vanished">Відмінити</translation>
     </message>
 </context>
 <context>
@@ -878,144 +877,144 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>Чи потребує цей комп&apos;ютер проксі для доступу до інтернету?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="69"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="70"/>
         <source>Proxy type:</source>
         <translation>Тип проксі:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="74"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="75"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="77"/>
         <source>None</source>
         <translation>Ніякого</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="92"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="93"/>
         <source>If you need a proxy to access the internet, select one from this list.</source>
         <extracomment>Description used by accessibility tech, such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="97"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="98"/>
         <source>Address:</source>
         <extracomment>Label indicating the textbox to place a proxy IP or URL</extracomment>
         <translation>Адреса:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="111"/>
         <source>IP address or hostname</source>
         <extracomment>Placeholder text of text box expecting an IP or URL for proxy</extracomment>
         <translation>IP адреса чи ім&apos;я сервера</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="115"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="116"/>
         <source>Enter the IP address or hostname of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the IP textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="119"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="120"/>
         <source>Port:</source>
         <extracomment>Label indicating the textbox to place a proxy port</extracomment>
         <translation>Порт:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="130"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="131"/>
         <source>Port</source>
         <extracomment>Name of the port label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="132"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="133"/>
         <source>Enter the port of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the Port textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="138"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="139"/>
         <source>Username:</source>
         <extracomment>Label indicating the textbox to place the proxy username</extracomment>
         <translation>Ім&apos;я:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="152"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="173"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="153"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="174"/>
         <source>Optional</source>
         <extracomment>Textbox placeholder text indicating the field is not required</extracomment>
         <translation>Опції</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="156"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="157"/>
         <source>Username</source>
         <extracomment>Name of the username label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="158"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="159"/>
         <source>If required, enter the username for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Username textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="162"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="163"/>
         <source>Password:</source>
         <extracomment>Label indicating the textbox to place the proxy password</extracomment>
         <translation>Пароль:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="177"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="178"/>
         <source>Password</source>
         <extracomment>Name of the password label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="180"/>
         <source>If required, enter the password for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Password textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="190"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="191"/>
         <source>Does this computer&apos;s Internet connection go through a firewall that only allows connections to certain ports?</source>
         <extracomment>Description for the purpose of the Allowed Ports textbox</extracomment>
         <translation>З&apos;єднання цього комп&apos;ютеру проходять через firewall який дозволяй з&apos;єднання тільки з певними портами?  </translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="211"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="212"/>
         <source>Allowed ports:</source>
         <extracomment>Label indicating the textbox to place the allowed ports</extracomment>
         <translation>Дозволені порти:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="220"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="221"/>
         <source>Example: 80,443</source>
         <extracomment>Textbox showing an example entry for the firewall allowed ports entry</extracomment>
         <translation>Наприклад: 80,443</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="224"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="225"/>
         <source>Allowed ports</source>
         <extracomment>Name of the allowed ports label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="236"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="237"/>
         <source>If this computer&apos;s Internet connection is censored, you will need to obtain and use bridge relays.</source>
         <translation>Якщо інтернет з&apos;єднання цього комп&apos;ютеру цензуруються, то вам потрібно отримати і використовувати ретранслятори.   </translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="251"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="262"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="252"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="263"/>
         <source>Enter one or more bridge relays (one per line):</source>
         <translation>Введіть один або декілька адрес ретрансляторів (один на лінію)</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="273"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="274"/>
         <source>Back</source>
         <extracomment>Button label for going back to previous screen</extracomment>
         <translation>Назад</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="284"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="285"/>
         <source>Connect</source>
         <extracomment>Button label for connecting to tor</extracomment>
         <translation>Підключення</translation>
@@ -1192,51 +1191,65 @@ Name of the button for launching the preferences window for accessibility tech l
     </message>
     <message>
         <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="114"/>
+        <source>Accepted</source>
+        <translation type="unfinished">Прийнято</translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="115"/>
         <source>Rejected</source>
         <translation type="unfinished">Відхилено</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="120"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
         <source>Cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
         <source>Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
         <source>Unkown Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
         <source>Bad File Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
         <source>Network Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="126"/>
         <source>File System Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="127"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="128"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="220"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="223"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="395"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="285"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="289"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="295"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="309"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="350"/>
+        <source>me</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="436"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/tego_ui/translation/ricochet_zh.ts
+++ b/src/tego_ui/translation/ricochet_zh.ts
@@ -21,29 +21,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="36"/>
-        <source>Ricochet Refresh web home page</source>
-        <extracomment>provides context for the URL for accessibility tech like screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="59"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="32"/>
         <source>The license of Ricochet Refresh and its dependencies</source>
-        <extracomment>summary of a block of text for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="60"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="33"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="65"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="37"/>
         <source>About</source>
         <translation type="unfinished">关于</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="39"/>
         <source>About page, contains license and version information</source>
         <extracomment>summary of the window&apos;s contents for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -105,37 +98,53 @@
 <context>
     <name>ContactActions</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="49"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <source>Could not successfully export conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="65"/>
         <source>Open Window</source>
         <extracomment>Context menu command to open the chat screen in a separate window</extracomment>
         <translation>打开窗口</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="70"/>
         <source>Details...</source>
         <extracomment>Context menu command to open a window showing the selected contact&apos;s details</extracomment>
         <translation>细节……</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="56"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="75"/>
         <source>Rename</source>
         <extracomment>Context menu command to rename the selected contact</extracomment>
         <translation>重命名</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="61"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="80"/>
         <source>Send File...</source>
         <extracomment>Context menu command to initiate a file transfer, opens a system file dialog</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="85"/>
+        <source>Export Conversation</source>
+        <extracomment>Context menu command to initiate a chat log export, opens a system file dialog to export to</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="91"/>
         <source>Remove</source>
         <extracomment>Context menu command to remove a contact from the contact list</extracomment>
         <translation>移除</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="74"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="98"/>
         <source>Contact options</source>
         <extracomment>Description of the items in the context menu for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -151,30 +160,36 @@
     </message>
     <message>
         <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="45"/>
+        <source>This ID is invalid</source>
+        <extracomment>Error message showed when the id doesn&apos;t comply with spec https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
         <source>You can&apos;t add yourself as a contact</source>
         <extracomment>Error message showed when user attempts to add themselves as a contact in their contact list</extracomment>
         <translation>不能添加自己为联系人</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="55"/>
         <source>Enter an ID starting with &lt;b&gt;ricochet:&lt;/b&gt;</source>
         <extracomment>Error message showed when the provided ricochet id is invalid</extracomment>
         <translation>输入一个ID并以&lt;b&gt;ricochet:&lt;/b&gt;打头</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="88"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="97"/>
         <source>Copied to clipboard</source>
         <extracomment>Message displayed when text is copied to the user&apos;s clipboard</extracomment>
         <translation>复制到剪贴板</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="103"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="112"/>
         <source>Copy</source>
         <extracomment>Text displayed on a button used to copy somethign to the user&apos;s clipboard</extracomment>
         <translation>复制</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="119"/>
         <source>Copies the ricochet id to the clipboard</source>
         <extracomment>Text description of ricochet id copy button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -393,20 +408,19 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Open links in default browser without prompting</source>
         <extracomment>Text description of an option to open URLs in default web browser when clicked</extracomment>
-        <translation>无需提示，直接在默认浏览器中打开链接</translation>
+        <translation type="vanished">无需提示，直接在默认浏览器中打开链接</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="44"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Play audio notifications</source>
         <extracomment>Text description of an option to play audio notifications when contacts log in, log out, and send messages</extracomment>
         <translation>使用声音提醒</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="61"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="77"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="62"/>
         <source>Volume</source>
         <extracomment>Label for a slider used to adjust audio notification volume
 ----------
@@ -414,8 +428,8 @@ Name of the slider used to adjust audio notification volume for accessibility te
         <translation>音量</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="91"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="129"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="114"/>
         <source>Language</source>
         <extracomment>Label for combobox where users can specify the UI language
 ----------
@@ -423,12 +437,12 @@ Name of the combobox used to select UI langauge for accessibility tech like scre
         <translation type="unfinished">语言</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="117"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="102"/>
         <source>Restart Ricochet to apply changes</source>
         <translation type="unfinished">应用并重启</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="131"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="116"/>
         <source>What language ricochet will use</source>
         <extracomment>Description of what the language combox is for for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -503,17 +517,17 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="157"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="151"/>
         <source>Version Seperator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="191"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="185"/>
         <source>Remove %1</source>
         <translation>移除%1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="192"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="186"/>
         <source>Do you want to permanently remove %1?</source>
         <translation>确定永久移除%1？</translation>
     </message>
@@ -545,79 +559,74 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>%1离线中</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="169"/>
         <source>File transfer file name</source>
         <extracomment>Description of the text displaying the filename of a file transfer, used by accessibility tech like screen readres</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="195"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="185"/>
         <source>File transfer progress</source>
         <extracomment>Description of progress bar displaying the file transfer progress, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="210"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="200"/>
         <source>File transfer status</source>
         <extracomment>Description of label displaying the current status of a file transfer, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="225"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="215"/>
         <source>Download</source>
         <extracomment>Label for file transfer &apos;Download&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="227"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="217"/>
         <source>Download file</source>
         <extracomment>Description of what the file transfer &apos;Download&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="244"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="234"/>
         <source>Cancel or reject</source>
         <extracomment>Label for file transfer &apos;Cancel&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="246"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="236"/>
         <source>Cancels or rejects a file transfer</source>
         <extracomment>Description of what the file transfer &apos;Cancel&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="310"/>
         <source>Copy ID</source>
         <extracomment>Text for context menu command to copy a ricochet contact id to clipboard</extracomment>
-        <translation>复制帐号</translation>
+        <translation type="vanished">复制帐号</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="281"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="312"/>
         <source>Copy Link</source>
         <extracomment>Text for context menu command to copy a url to the clipboard</extracomment>
-        <translation>复制链接</translation>
+        <translation type="vanished">复制链接</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="287"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="318"/>
         <source>Open with Browser</source>
         <extracomment>Text for context menu command to open a url in a web browser</extracomment>
-        <translation>用浏览器打开</translation>
+        <translation type="vanished">用浏览器打开</translation>
     </message>
     <message>
         <source>Add as Contact</source>
         <translation type="vanished">添加为联系人</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="335"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="262"/>
         <source>Copy Message</source>
         <extracomment>Text for context menu command to copy an entire message to clipboard</extracomment>
         <translation>复制消息</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="343"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="270"/>
         <source>Copy Selection</source>
         <extracomment>Text for context menu command to copy selected text to clipboard</extracomment>
         <translation>复制选择内容</translation>
@@ -701,38 +710,23 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>OpenBrowserDialog</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="41"/>
-        <source>&lt;b&gt;Warning!&lt;/b&gt; Opening links with your default browser will harm your security and anonymity.&lt;br&gt;&lt;br&gt;You can &lt;a href=&apos;.&apos;&gt;copy to the clipboard&lt;/a&gt; instead.</source>
-        <extracomment>Label displayed when user clicks on a link</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Don&apos;t ask again for links from %1</source>
         <translation type="vanished">不再询问来自%1的链接</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="50"/>
-        <source>Warning</source>
-        <extracomment>Name of warning label used with accessibility tech such as screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="65"/>
         <source>Don&apos;t ask again for any links (not recommended!)</source>
         <extracomment>Checkbox option text for when user clicks on a link</extracomment>
-        <translation>不再询问任何链接(不推荐)</translation>
+        <translation type="vanished">不再询问任何链接(不推荐)</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="73"/>
         <source>Open Browser</source>
         <extracomment>Label on button to open link in a web browser</extracomment>
-        <translation>打开浏览器</translation>
+        <translation type="vanished">打开浏览器</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="84"/>
         <source>Cancel</source>
         <extracomment>Label on cancel button</extracomment>
-        <translation>取消</translation>
+        <translation type="vanished">取消</translation>
     </message>
 </context>
 <context>
@@ -874,144 +868,144 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>这台电脑需要通过代理来连接网络吗？</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="69"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="70"/>
         <source>Proxy type:</source>
         <translation>代理类型：</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="74"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="75"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="77"/>
         <source>None</source>
         <translation>None</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="92"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="93"/>
         <source>If you need a proxy to access the internet, select one from this list.</source>
         <extracomment>Description used by accessibility tech, such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="97"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="98"/>
         <source>Address:</source>
         <extracomment>Label indicating the textbox to place a proxy IP or URL</extracomment>
         <translation>地址：</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="111"/>
         <source>IP address or hostname</source>
         <extracomment>Placeholder text of text box expecting an IP or URL for proxy</extracomment>
         <translation>IP地址或主机名</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="115"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="116"/>
         <source>Enter the IP address or hostname of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the IP textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="119"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="120"/>
         <source>Port:</source>
         <extracomment>Label indicating the textbox to place a proxy port</extracomment>
         <translation>端口：</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="130"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="131"/>
         <source>Port</source>
         <extracomment>Name of the port label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="132"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="133"/>
         <source>Enter the port of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the Port textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="138"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="139"/>
         <source>Username:</source>
         <extracomment>Label indicating the textbox to place the proxy username</extracomment>
         <translation>用户名：</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="152"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="173"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="153"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="174"/>
         <source>Optional</source>
         <extracomment>Textbox placeholder text indicating the field is not required</extracomment>
         <translation>可选</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="156"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="157"/>
         <source>Username</source>
         <extracomment>Name of the username label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="158"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="159"/>
         <source>If required, enter the username for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Username textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="162"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="163"/>
         <source>Password:</source>
         <extracomment>Label indicating the textbox to place the proxy password</extracomment>
         <translation>密码：</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="177"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="178"/>
         <source>Password</source>
         <extracomment>Name of the password label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="180"/>
         <source>If required, enter the password for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Password textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="190"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="191"/>
         <source>Does this computer&apos;s Internet connection go through a firewall that only allows connections to certain ports?</source>
         <extracomment>Description for the purpose of the Allowed Ports textbox</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="211"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="212"/>
         <source>Allowed ports:</source>
         <extracomment>Label indicating the textbox to place the allowed ports</extracomment>
         <translation>允许的端口：</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="220"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="221"/>
         <source>Example: 80,443</source>
         <extracomment>Textbox showing an example entry for the firewall allowed ports entry</extracomment>
         <translation>例如：80,443</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="224"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="225"/>
         <source>Allowed ports</source>
         <extracomment>Name of the allowed ports label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="236"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="237"/>
         <source>If this computer&apos;s Internet connection is censored, you will need to obtain and use bridge relays.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="251"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="262"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="252"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="263"/>
         <source>Enter one or more bridge relays (one per line):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="273"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="274"/>
         <source>Back</source>
         <extracomment>Button label for going back to previous screen</extracomment>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="284"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="285"/>
         <source>Connect</source>
         <extracomment>Button label for connecting to tor</extracomment>
         <translation>连接</translation>
@@ -1188,51 +1182,65 @@ Name of the button for launching the preferences window for accessibility tech l
     </message>
     <message>
         <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="114"/>
+        <source>Accepted</source>
+        <translation type="unfinished">已接受</translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="115"/>
         <source>Rejected</source>
         <translation type="unfinished">已拒绝</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="120"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
         <source>Cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
         <source>Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
         <source>Unkown Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
         <source>Bad File Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
         <source>Network Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="126"/>
         <source>File System Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="127"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="128"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="220"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="223"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="395"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="285"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="289"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="295"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="309"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="350"/>
+        <source>me</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="436"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/tego_ui/translation/ricochet_zh_HK.ts
+++ b/src/tego_ui/translation/ricochet_zh_HK.ts
@@ -21,29 +21,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="36"/>
-        <source>Ricochet Refresh web home page</source>
-        <extracomment>provides context for the URL for accessibility tech like screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="59"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="32"/>
         <source>The license of Ricochet Refresh and its dependencies</source>
-        <extracomment>summary of a block of text for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="60"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="33"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="65"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="37"/>
         <source>About</source>
         <translation type="unfinished">關於</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/AboutPreferences.qml" line="39"/>
         <source>About page, contains license and version information</source>
         <extracomment>summary of the window&apos;s contents for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -105,37 +98,53 @@
 <context>
     <name>ContactActions</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="49"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <source>Could not successfully export conversation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="65"/>
         <source>Open Window</source>
         <extracomment>Context menu command to open the chat screen in a separate window</extracomment>
         <translation>開啟視窗</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="51"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="70"/>
         <source>Details...</source>
         <extracomment>Context menu command to open a window showing the selected contact&apos;s details</extracomment>
         <translation>細節</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="56"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="75"/>
         <source>Rename</source>
         <extracomment>Context menu command to rename the selected contact</extracomment>
         <translation>重新命名</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="61"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="80"/>
         <source>Send File...</source>
         <extracomment>Context menu command to initiate a file transfer, opens a system file dialog</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="67"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="85"/>
+        <source>Export Conversation</source>
+        <extracomment>Context menu command to initiate a chat log export, opens a system file dialog to export to</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="91"/>
         <source>Remove</source>
         <extracomment>Context menu command to remove a contact from the contact list</extracomment>
         <translation>移除</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="74"/>
+        <location filename="../../libtego_ui/ui/qml/ContactActions.qml" line="98"/>
         <source>Contact options</source>
         <extracomment>Description of the items in the context menu for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -151,30 +160,36 @@
     </message>
     <message>
         <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="45"/>
+        <source>This ID is invalid</source>
+        <extracomment>Error message showed when the id doesn&apos;t comply with spec https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
         <source>You can&apos;t add yourself as a contact</source>
         <extracomment>Error message showed when user attempts to add themselves as a contact in their contact list</extracomment>
         <translation>你不能新增自己為聯絡人</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="50"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="55"/>
         <source>Enter an ID starting with &lt;b&gt;ricochet:&lt;/b&gt;</source>
         <extracomment>Error message showed when the provided ricochet id is invalid</extracomment>
         <translation>輸入ID開始使用 &lt;b&gt;ricochet:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="88"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="97"/>
         <source>Copied to clipboard</source>
         <extracomment>Message displayed when text is copied to the user&apos;s clipboard</extracomment>
         <translation>複製到剪貼簿</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="103"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="112"/>
         <source>Copy</source>
         <extracomment>Text displayed on a button used to copy somethign to the user&apos;s clipboard</extracomment>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/ContactIDField.qml" line="119"/>
         <source>Copies the ricochet id to the clipboard</source>
         <extracomment>Text description of ricochet id copy button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -397,20 +412,19 @@
         <translation>使用單一視窗來對話</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Open links in default browser without prompting</source>
         <extracomment>Text description of an option to open URLs in default web browser when clicked</extracomment>
-        <translation>在原瀏覧器中開啟連結而不要跳出新視窗</translation>
+        <translation type="vanished">在原瀏覧器中開啟連結而不要跳出新視窗</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="44"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="29"/>
         <source>Play audio notifications</source>
         <extracomment>Text description of an option to play audio notifications when contacts log in, log out, and send messages</extracomment>
         <translation>開啟通知音訊</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="61"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="77"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="46"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="62"/>
         <source>Volume</source>
         <extracomment>Label for a slider used to adjust audio notification volume
 ----------
@@ -418,8 +432,8 @@ Name of the slider used to adjust audio notification volume for accessibility te
         <translation>音量</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="91"/>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="129"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="114"/>
         <source>Language</source>
         <extracomment>Label for combobox where users can specify the UI language
 ----------
@@ -427,12 +441,12 @@ Name of the combobox used to select UI langauge for accessibility tech like scre
         <translation type="unfinished">語言</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="117"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="102"/>
         <source>Restart Ricochet to apply changes</source>
         <translation type="unfinished">重啟Ricochet 以更新改變</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="131"/>
+        <location filename="../../libtego_ui/ui/qml/GeneralPreferences.qml" line="116"/>
         <source>What language ricochet will use</source>
         <extracomment>Description of what the language combox is for for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
@@ -507,17 +521,17 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="157"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="151"/>
         <source>Version Seperator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="191"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="185"/>
         <source>Remove %1</source>
         <translation>移除%1</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="192"/>
+        <location filename="../../libtego_ui/ui/MainWindow.cpp" line="186"/>
         <source>Do you want to permanently remove %1?</source>
         <translation>你是否要永遠移除%1?</translation>
     </message>
@@ -549,79 +563,74 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>%1 已離線</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="169"/>
         <source>File transfer file name</source>
         <extracomment>Description of the text displaying the filename of a file transfer, used by accessibility tech like screen readres</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="195"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="185"/>
         <source>File transfer progress</source>
         <extracomment>Description of progress bar displaying the file transfer progress, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="210"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="200"/>
         <source>File transfer status</source>
         <extracomment>Description of label displaying the current status of a file transfer, used by accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="225"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="215"/>
         <source>Download</source>
         <extracomment>Label for file transfer &apos;Download&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="227"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="217"/>
         <source>Download file</source>
         <extracomment>Description of what the file transfer &apos;Download&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="244"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="234"/>
         <source>Cancel or reject</source>
         <extracomment>Label for file transfer &apos;Cancel&apos; button for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="246"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="236"/>
         <source>Cancels or rejects a file transfer</source>
         <extracomment>Description of what the file transfer &apos;Cancel&apos; button does for accessibility tech like screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="310"/>
         <source>Copy ID</source>
         <extracomment>Text for context menu command to copy a ricochet contact id to clipboard</extracomment>
-        <translation>複製ID</translation>
+        <translation type="vanished">複製ID</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="281"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="312"/>
         <source>Copy Link</source>
         <extracomment>Text for context menu command to copy a url to the clipboard</extracomment>
-        <translation>複製連結</translation>
+        <translation type="vanished">複製連結</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="287"/>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="318"/>
         <source>Open with Browser</source>
         <extracomment>Text for context menu command to open a url in a web browser</extracomment>
-        <translation>開啟瀏覧器</translation>
+        <translation type="vanished">開啟瀏覧器</translation>
     </message>
     <message>
         <source>Add as Contact</source>
         <translation type="vanished">新增聯絡人</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="335"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="262"/>
         <source>Copy Message</source>
         <extracomment>Text for context menu command to copy an entire message to clipboard</extracomment>
         <translation>複製訊息</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="343"/>
+        <location filename="../../libtego_ui/ui/qml/MessageDelegate.qml" line="270"/>
         <source>Copy Selection</source>
         <extracomment>Text for context menu command to copy selected text to clipboard</extracomment>
         <translation>複製選項</translation>
@@ -705,38 +714,28 @@ Name of the button for launching the preferences window for accessibility tech l
 <context>
     <name>OpenBrowserDialog</name>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="41"/>
         <source>&lt;b&gt;Warning!&lt;/b&gt; Opening links with your default browser will harm your security and anonymity.&lt;br&gt;&lt;br&gt;You can &lt;a href=&apos;.&apos;&gt;copy to the clipboard&lt;/a&gt; instead.</source>
         <extracomment>Label displayed when user clicks on a link</extracomment>
-        <translation>&lt;b&gt;警告!&lt;/b&gt; 用你的瀏覧器直接開啟連結可能會對安全與匿名性造成威脅.&lt;br&gt;&lt;br&gt;你可另以&lt;a href=&apos;.&apos;&gt;複製到剪貼簿&lt;/a&gt;取代 .</translation>
+        <translation type="vanished">&lt;b&gt;警告!&lt;/b&gt; 用你的瀏覧器直接開啟連結可能會對安全與匿名性造成威脅.&lt;br&gt;&lt;br&gt;你可另以&lt;a href=&apos;.&apos;&gt;複製到剪貼簿&lt;/a&gt;取代 .</translation>
     </message>
     <message>
         <source>Don&apos;t ask again for links from %1</source>
         <translation type="vanished">別再請求來自%1的連結</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="50"/>
-        <source>Warning</source>
-        <extracomment>Name of warning label used with accessibility tech such as screen readers</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="65"/>
         <source>Don&apos;t ask again for any links (not recommended!)</source>
         <extracomment>Checkbox option text for when user clicks on a link</extracomment>
-        <translation>別再請求任何連結(不建議!)</translation>
+        <translation type="vanished">別再請求任何連結(不建議!)</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="73"/>
         <source>Open Browser</source>
         <extracomment>Label on button to open link in a web browser</extracomment>
-        <translation>開啟瀏覧器</translation>
+        <translation type="vanished">開啟瀏覧器</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/OpenBrowserDialog.qml" line="84"/>
         <source>Cancel</source>
         <extracomment>Label on cancel button</extracomment>
-        <translation>取消</translation>
+        <translation type="vanished">取消</translation>
     </message>
 </context>
 <context>
@@ -878,144 +877,144 @@ Name of the button for launching the preferences window for accessibility tech l
         <translation>這台電腦是否需要透過代理主機來連網?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="69"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="70"/>
         <source>Proxy type:</source>
         <translation>Proxy 類型:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="74"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="76"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="75"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="77"/>
         <source>None</source>
         <translation>無</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="92"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="93"/>
         <source>If you need a proxy to access the internet, select one from this list.</source>
         <extracomment>Description used by accessibility tech, such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="97"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="98"/>
         <source>Address:</source>
         <extracomment>Label indicating the textbox to place a proxy IP or URL</extracomment>
         <translation>地址:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="110"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="111"/>
         <source>IP address or hostname</source>
         <extracomment>Placeholder text of text box expecting an IP or URL for proxy</extracomment>
         <translation>I位置或主機名稱</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="115"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="116"/>
         <source>Enter the IP address or hostname of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the IP textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="119"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="120"/>
         <source>Port:</source>
         <extracomment>Label indicating the textbox to place a proxy port</extracomment>
         <translation>埠部:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="130"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="131"/>
         <source>Port</source>
         <extracomment>Name of the port label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="132"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="133"/>
         <source>Enter the port of the proxy you wish to connect to</source>
         <extracomment>Description of what to enter into the Port textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="138"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="139"/>
         <source>Username:</source>
         <extracomment>Label indicating the textbox to place the proxy username</extracomment>
         <translation>使用者名稱:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="152"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="173"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="153"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="174"/>
         <source>Optional</source>
         <extracomment>Textbox placeholder text indicating the field is not required</extracomment>
         <translation>選項</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="156"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="157"/>
         <source>Username</source>
         <extracomment>Name of the username label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="158"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="159"/>
         <source>If required, enter the username for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Username textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="162"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="163"/>
         <source>Password:</source>
         <extracomment>Label indicating the textbox to place the proxy password</extracomment>
         <translation>密碼:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="177"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="178"/>
         <source>Password</source>
         <extracomment>Name of the password label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="179"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="180"/>
         <source>If required, enter the password for the proxy you wish to connect to</source>
         <extracomment>Description to enter into the Password textbox, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="190"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="191"/>
         <source>Does this computer&apos;s Internet connection go through a firewall that only allows connections to certain ports?</source>
         <extracomment>Description for the purpose of the Allowed Ports textbox</extracomment>
         <translation>這台電腦的網路連線是否透過防火牆，只能充許某些埠號來連網?</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="211"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="212"/>
         <source>Allowed ports:</source>
         <extracomment>Label indicating the textbox to place the allowed ports</extracomment>
         <translation>允許埠部:</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="220"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="221"/>
         <source>Example: 80,443</source>
         <extracomment>Textbox showing an example entry for the firewall allowed ports entry</extracomment>
         <translation>示範: 80,443</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="224"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="225"/>
         <source>Allowed ports</source>
         <extracomment>Name of the allowed ports label, used by accessibility tech such as screen readers</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="236"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="237"/>
         <source>If this computer&apos;s Internet connection is censored, you will need to obtain and use bridge relays.</source>
         <translation>如果這台電腦的網路連線遭到監控，你必須改用中續撟接服務</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="251"/>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="262"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="252"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="263"/>
         <source>Enter one or more bridge relays (one per line):</source>
         <translation>輸入一個以上的中續橋接(一行一個):</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="273"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="274"/>
         <source>Back</source>
         <extracomment>Button label for going back to previous screen</extracomment>
         <translation>退後</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="284"/>
+        <location filename="../../libtego_ui/ui/qml/TorConfigurationPage.qml" line="285"/>
         <source>Connect</source>
         <extracomment>Button label for connecting to tor</extracomment>
         <translation>連線</translation>
@@ -1192,51 +1191,65 @@ Name of the button for launching the preferences window for accessibility tech l
     </message>
     <message>
         <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="114"/>
+        <source>Accepted</source>
+        <translation type="unfinished">已接受</translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="115"/>
         <source>Rejected</source>
         <translation type="unfinished">拒絕</translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="120"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
         <source>Cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="121"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
         <source>Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="122"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
         <source>Unkown Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="123"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
         <source>Bad File Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="124"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
         <source>Network Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="125"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="126"/>
         <source>File System Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="127"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="128"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="220"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="223"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="395"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="285"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="289"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="295"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="309"/>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="350"/>
+        <source>me</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../libtego_ui/shims/ConversationModel.cpp" line="436"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
@m-simonelli changes from your PR:

 - fixed bug in to_string(tego_file_hash_t* const)
 - fixed file transfer UI issues with added 'Accepted' state
 - logging timestamps are all calculated by the local user
    (ie timestamps from messages are ignored)
 - tweaked Export Conversation UX:
    log file is offered to be saved as ~/Downloads/$contact-$timestamp.log
    tweaks to log output format
 - some internals cleanup, timestamps are saved as QDateTime
    on the base Event struct
 - cancelling log save does not trigger error box
 - fixed file transfer UI issues with added 'Accepted' state