### PR TITLE
Fix listen IP address on Workstation/Gateway setups

### DIFF
--- a/src/libtego/source/core/UserIdentity.cpp
+++ b/src/libtego/source/core/UserIdentity.cpp
@@ -111,6 +111,13 @@ void UserIdentity::setupService(const QString& serviceID)
     QHostAddress address = QHostAddress::LocalHost;
     quint16 port = 0;
 
+    // If Ricochet is running on a different machine than Tor (i.e.
+    // Workstation/Gateway setup), then listen on 0.0.0.0 as per this spec:
+    // http://www.dds6qkxpwdeubwucdiaord2xgbbeyds25rbsgr73tbfpqpt4a6vjwsyd.onion/wiki/Dev/Whonix_friendly_applications_best_practices#Listen_Interface
+    if (QFile::exists("/usr/share/anon-ws-base-files/workstation")) {
+        address = QHostAddress::AnyIPv4;
+    }
+
     m_incomingServer = new QTcpServer(this);
     if (!m_incomingServer->listen(address, port)) {
         // XXX error case


### PR DESCRIPTION
Without this PR, connections fail if both peers are using Whonix; with this PR, such connections now work.  (Both tests done with https://github.com/blueprint-freespeech/ricochet-refresh/pull/101 applied.)