### PR TITLE
Upgrade deprecated Qt and protobuf functions

### DIFF
--- a/src/libtego/source/protocol/Channel_p.h
+++ b/src/libtego/source/protocol/Channel_p.h
@@ -69,7 +69,7 @@ public:
 
 template<typename T> bool Channel::sendMessage(const T &message)
 {
-    int size = message.ByteSize();
+    size_t size = message.ByteSizeLong();
     if (size > ConnectionPrivate::PacketMaxDataSize) {
         TEGO_BUG() << "Message on" << type() << "channel is too big -" << size << "bytes:"
                    << QString::fromStdString(message.DebugString());
@@ -82,7 +82,7 @@ template<typename T> bool Channel::sendMessage(const T &message)
         return false;
     }
 
-    QByteArray packet(size, 0);
+    QByteArray packet(int(size), 0);
     quint8 *end = message.SerializeWithCachedSizesToArray(reinterpret_cast<quint8*>(packet.data()));
     quint8 *expected_end = reinterpret_cast<quint8*>(packet.data() + size);
     if (end != expected_end) {

--- a/src/libtego/source/tor/TorProcess.cpp
+++ b/src/libtego/source/tor/TorProcess.cpp
@@ -181,10 +181,10 @@ void TorProcess::stop()
     if (d->process.state() == QProcess::Running) {
         d->process.terminate();
         if (!d->process.waitForFinished(5000)) {
-            qWarning() << "Tor process" << d->process.pid() << "did not respond to terminate, killing...";
+            qWarning() << "Tor process" << d->process.processId() << "did not respond to terminate, killing...";
             d->process.kill();
             if (!d->process.waitForFinished(2000)) {
-                qCritical() << "Tor process" << d->process.pid() << "did not respond to kill!";
+                qCritical() << "Tor process" << d->process.processId() << "did not respond to kill!";
             }
         }
     }


### PR DESCRIPTION
Upgrade deprecated Qt and protobuf functions:

`protobuf::MessageLite::ByteSize()`
https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.message_lite#MessageLite.ByteSize

`QProcess::pid()`
https://doc.qt.io/qt-5/qprocess-obsolete.html#pid