### PR TITLE
Build instructions: add more qt packages for Debian and Ubuntu

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -29,7 +29,8 @@ yum install cmake tor gcc-c++ protobuf-devel protobuf-compiler openssl-devel fmt
 ```sh
 apt install cmake tor build-essential libprotobuf-dev protobuf-compiler libssl-dev \
             libfmt-dev qtbase5-dev qtdeclarative5-dev qml-module-qtquick-layouts \
-            qml-module-qtquick-controls qml-module-qtquick-dialogs
+            qml-module-qtquick-controls qml-module-qtquick-dialogs qttools5-dev \
+            qtmultimedia5-dev qtquickcontrols2-5-dev
 ```
 
 If the `qml-module-qtquick` packages aren't available, try `qtdeclarative5-controls-plugin` instead.


### PR DESCRIPTION
I needed to install these packages for the build to work. Without them, cmake failed looking for e.g. `Qt5LinguistToolsConfig.cmake`.

This has only been tested on my system, which is running Ubuntu 22.04.2 LTS.

Partly addresses
https://github.com/blueprint-freespeech/ricochet-refresh/issues/142, though it looks like the assignee intends/intended to do a more thorough analysis of the set of deps needed, so not sure it'd make sense to close it.