### PR TITLE
use EVP API of openssl3

### DIFF
--- a/src/libtego/source/utils/CryptoKey.cpp
+++ b/src/libtego/source/utils/CryptoKey.cpp
@@ -174,8 +174,11 @@ QByteArray torControlHashedPassword(const QByteArray &password)
 
     int count = (16u + (96 & 15)) << ((96 >> 4) + 6);
 
-    EVP_MD_CTX *mdctx;
-    mdctx = EVP_MD_CTX_new();
+    // avoid leaking mdctx_hidden when throwing an exception
+    EVP_MD_CTX *mdctx_hidden = NULL;
+    mdctx_hidden = EVP_MD_CTX_new();
+    unique_ptr<EVP_MD_CTX, decltype(EVP_MD_CTX_free)> mdctx(mdctx_hidden, EVP_MD_CTX_free);
+
     if (mdctx == NULL) {
         throw std::runtime_error("Failed to create SHA1 context");
     }

--- a/src/libtego/source/utils/CryptoKey.cpp
+++ b/src/libtego/source/utils/CryptoKey.cpp
@@ -174,10 +174,9 @@ QByteArray torControlHashedPassword(const QByteArray &password)
 
     int count = (16u + (96 & 15)) << ((96 >> 4) + 6);
 
-    // avoid leaking mdctx_hidden when throwing an exception
-    EVP_MD_CTX *mdctx_hidden = NULL;
-    mdctx_hidden = EVP_MD_CTX_new();
-    unique_ptr<EVP_MD_CTX, decltype(EVP_MD_CTX_free)> mdctx(mdctx_hidden, EVP_MD_CTX_free);
+    // avoid leaking mdctx when throwing an exception
+    unique_ptr<EVP_MD_CTX, decltype(EVP_MD_CTX_free)> mdctx_ptr(EVP_MD_CTX_new(), EVP_MD_CTX_free);
+    #define mdctx mdctx_ptr.get()
 
     if (mdctx == NULL) {
         throw std::runtime_error("Failed to create SHA1 context");

--- a/src/libtego/source/utils/CryptoKey.cpp
+++ b/src/libtego/source/utils/CryptoKey.cpp
@@ -174,19 +174,36 @@ QByteArray torControlHashedPassword(const QByteArray &password)
 
     int count = (16u + (96 & 15)) << ((96 >> 4) + 6);
 
-    SHA_CTX hash;
-    SHA1_Init(&hash);
+    EVP_MD_CTX *mdctx;
+    mdctx = EVP_MD_CTX_new();
+    if (mdctx == NULL) {
+        throw std::runtime_error("Failed to create SHA1 context");
+    }
+
+    if (EVP_DigestInit_ex(mdctx, EVP_sha1(), NULL) != 1) {
+        throw std::runtime_error("Failed to init SHA1 context");
+    }
 
     QByteArray tmp = salt + password;
     while (count)
     {
         int c = qMin(count, tmp.size());
-        SHA1_Update(&hash, reinterpret_cast<const void*>(tmp.constData()), static_cast<size_t>(c));
+        if (EVP_DigestUpdate(mdctx, reinterpret_cast<const void*>(tmp.constData()), static_cast<size_t>(c)) != 1) {
+            throw std::runtime_error("Failed to update SHA1 digest");
+        }
         count -= c;
     }
 
     unsigned char md[20];
-    SHA1_Final(md, &hash);
+    unsigned int md_size = 0;
+    if (1 != EVP_DigestFinal_ex(mdctx, md, &md_size)) {
+        throw std::runtime_error("Failed to finalize SHA1 digest");
+    }
+    if (md_size != 20) {
+        throw std::runtime_error("Invalid SHA1 digest size");
+    }
+
+    EVP_MD_CTX_free(mdctx);
 
     /* 60 is the hex-encoded value of 96, which is a constant used by Tor's algorithm. */
     return QByteArray("16:") + salt.toHex().toUpper() + QByteArray("60") +


### PR DESCRIPTION
fix: warning: `‘int SHA1_Init(SHA_CTX*)’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]`

https://wiki.openssl.org/index.php/EVP_Message_Digests

continue #172 