### PR TITLE
Add Abseil as libtego's dependency to fix linker errors

### DIFF
--- a/src/libtego/CMakeLists.txt
+++ b/src/libtego/CMakeLists.txt
@@ -103,6 +103,8 @@ include(FindProtobuf)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
+find_package(absl REQUIRED)
+
 add_library(
     tego STATIC
     include/tego/logger.hpp
@@ -249,6 +251,7 @@ endif ()
 target_link_libraries(tego PRIVATE fmt::fmt-header-only)
 target_link_libraries(tego PRIVATE OpenSSL::Crypto)
 target_link_libraries(tego PRIVATE protobuf::libprotobuf)
+target_link_libraries(tego PRIVATE absl::log_internal_check_op)
 
 # QT
 target_link_libraries(


### PR DESCRIPTION
ricochet-refresh's build is failing with a `DSO missing from command line` error, on Arch Linux (binutils 2.42), when liking the final binary.

```
/usr/bin/ld: ../libtego/libtego.a(ControlChannel.pb.cc.o): undefined reference to symbol '_ZN4absl12lts_2023080212log_internal17MakeCheckOpStringIllEEPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEET_T0_PKc'
/usr/bin/ld: /usr/lib/libabsl_log_internal_check_op.so.2308.0.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [ricochet-refresh/CMakeFiles/ricochet-refresh.dir/build.make:440: ricochet-refresh/ricochet-refresh/ricochet-refresh] Error 1
make[1]: *** [CMakeFiles/Makefile2:363: ricochet-refresh/CMakeFiles/ricochet-refresh.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

libabsl_log_internal_check_op.so is needed to build libtego.a because protobuf depends on it. Setting the linker flags to `-Wl,--copy-dt-needed-entries` as I did on the [AUR PKGBUILD](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=ricochet-refresh&id=d6eb54a4e2da881843219aa2b8f4dc29bca11f99) works around the issue. However it goes against the now default behaviour of binutils of not recursively fetching dependencies for libs when linking.

Adding an explicit link to Abseil as I am doing in this PR fixes the error in the manner binutils now deems proper. On the other hand, it makes libtego build files depend on the internals of protobuf. As such I am unsure if this is the proper way to go. Reviews and comments are gladly welcomed.