### PR TITLE
ui: deactivate bridge configuration panel when no built-in bridges ar…

### DIFF
--- a/src/ricochet-refresh/ui/TorConfigurationPage.qml
+++ b/src/ricochet-refresh/ui/TorConfigurationPage.qml
@@ -309,8 +309,16 @@ Column {
     }
 
     GroupBox {
+        id: bridgesPanel
         width: parent.width
         title: "Bridges"
+
+        property bool bridgesDefined: torControl.getBridgeTypes().length != 0
+
+        SystemPalette {
+            id: bridgesPalette
+            colorGroup: bridgesPanel.bridgesDefined ? SystemPalette.Active : SystemPalette.Disabled
+        }
 
         ColumnLayout {
         width: parent.width
@@ -330,11 +338,13 @@ Column {
             RowLayout {
                 Label {
                     text: qsTr("Type:")
+                    color: bridgesPalette.text
                 }
 
                 ComboBox {
                     // Displays the selection of a bridge type (obfs4, meek-azure, etc)
                     id: bridgeTypeField
+                    enabled: bridgesPanel.bridgesDefined
                     model: ListModel {
                         id: bridgeTypeModel
                         ListElement { text: qsTr("None"); type: "none" }
@@ -353,11 +363,6 @@ Column {
                     textRole: "text"
 
                     property string selectedType: currentIndex >= 0 ? model.get(currentIndex).type : ""
-
-                    SystemPalette {
-                        id: bridgePalette
-                        colorGroup: setup.bridgeType == "" ? SystemPalette.Disabled : SystemPalette.Active
-                    }
 
                     Accessible.role: Accessible.ComboBox
                     Accessible.name: selectedType


### PR DESCRIPTION
This MR disables the bridges configuration panel when no bridges are defined. When disabled, it looks like the image below.

![TorConfiguration](https://github.com/blueprint-freespeech/ricochet-refresh/assets/116489784/38e68f79-a095-4afe-9197-f15f459183c8)

Tested on a bridgeless `linux-aarch64` build. The `SystemPalette` I removed was not in use any more AFAICS. Please keep in mind that I'm new to the `ricochet-refresh` codebase and to QML too, so there may be a better way to achieve the same thing.