### PR TITLE
Fix crash when using bridges on non-UTF-8 locale Windows systems (e.g., Chinese)

### DIFF
--- a/src/ricochet-refresh-qt/shims/TorControl.cpp
+++ b/src/ricochet-refresh-qt/shims/TorControl.cpp
@@ -260,9 +260,11 @@ namespace shims
             std::vector<tego_pluggable_transport_config*> pt_configs;
             for(auto it = pluggableTransportConfigs.begin(); it != pluggableTransportConfigs.end(); ++it) {
                 // marshall binary_name
-                const auto binaryPath = qApp->applicationDirPath().toStdString() + "/pluggable_transports/" + it->binary_name;
-                const auto binaryPathLen = binaryPath.size();
-                const auto rawBinaryPath = binaryPath.c_str();
+                // Use toUtf8() instead of toStdString() to ensure proper UTF-8 encoding
+                // on non-UTF-8 locale systems (e.g., Chinese Windows uses GBK by default)
+                const auto binaryPathUtf8 = (qApp->applicationDirPath() + QStringLiteral("/pluggable_transports/") + QString::fromStdString(it->binary_name)).toUtf8();
+                const auto binaryPathLen = static_cast<size_t>(binaryPathUtf8.size());
+                const auto rawBinaryPath = binaryPathUtf8.constData();
 
                 // marshall transports
                 const auto transportCount = it->transports.size();


### PR DESCRIPTION
### Problem

When using pluggable transports (bridges) on Windows systems with non-UTF-8 default locale (e.g., Chinese Windows which uses GBK encoding), the application crashes with the following error:

```
[warn] CreateProcessA() failed: The system cannot find the file specified.
[warn] Managed proxy "pluggable_transports/lyrebird.exe" process terminated with status code 0
[err] tor_assertion_failed_: Bug: transports.c:520: proxy_prepare_for_restart: Assertion mp->conf_state == PT_PROTO_COMPLETED failed; aborting.
```

The `pluggable_transports` directory may also appear as a corrupted/garbled file instead of a proper directory.

### Root Cause

In TorControl.cpp, the pluggable transport binary path was constructed using `QString::toStdString()`:

```cpp
const auto binaryPath = qApp->applicationDirPath().toStdString() + "/pluggable_transports/" + it->binary_name;
```

On Windows, `QString::toStdString()` converts the string using the system's default locale encoding (e.g., GBK on Chinese Windows), **not UTF-8**. However, the Rust FFI code (ffi.rs) expects the path to be UTF-8 encoded:

```rust
let binary_path = std::str::from_utf8(binary_path)?;
```

This encoding mismatch causes path corruption when the Windows username or installation path contains non-ASCII characters.

### Solution

Use `QString::toUtf8()` instead of `QString::toStdString()` to ensure the path is always encoded as UTF-8, which the Rust backend expects:

```cpp
const auto binaryPathUtf8 = (qApp->applicationDirPath() + QStringLiteral("/pluggable_transports/") + QString::fromStdString(it->binary_name)).toUtf8();
```